### PR TITLE
Use docker bridge IP for DB_IP

### DIFF
--- a/lib/_helpers.sh
+++ b/lib/_helpers.sh
@@ -96,7 +96,7 @@ __set_admiral_ip() {
 
 __set_db_ip() {
   __process_msg "Setting value of DB IP address"
-  local db_ip="127.0.0.1"
+  local db_ip="172.17.0.1"
   if [ "INSTALL_MODE" == "cluster" ]; then
     __process_msg "Please enter value of db IP address"
     read response


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/41

Uses 172.17.0.1 for the DB_IP

Tested by bringing up a new install on a DO box. The admiral container was able to successfully connect to the db.