### PR TITLE
Check if db container is running before proceeding

### DIFF
--- a/common/scripts/docker/installDb.sh
+++ b/common/scripts/docker/installDb.sh
@@ -57,6 +57,29 @@ __validate_db_mounts() {
   fi
 }
 
+__check_db() {
+  local interval=3
+  local db_timeout=60
+  local counter=0
+  local db_booted=false
+
+  while [ $db_booted != true ] && [ $counter -lt $db_timeout ]; do
+    local db_container=$(sudo docker ps | grep $COMPONENT | awk '{print $1}')
+    if [ "$db_container" != "" ]; then
+      __process_msg "Database container found"
+      db_booted=true
+    else
+      __process_msg "Waiting for database container"
+      let "counter = $counter + $interval"
+      sleep $interval
+    fi
+  done
+  if [ $db_booted = false ]; then
+    __process_msg "Failed to boot database container"
+    exit 1
+  fi
+}
+
 __run_db() {
   __process_msg "Running database container"
 
@@ -85,7 +108,7 @@ __run_db() {
     "
 
     eval "$run_cmd"
-    __process_msg "Database container successfully running"
+    __check_db
   fi
 }
 

--- a/common/scripts/docker/installVault.sh
+++ b/common/scripts/docker/installVault.sh
@@ -60,7 +60,7 @@ __run_vault() {
   "
 
   eval "$run_cmd"
-  __process_msg "Database container successfully running"
+  __process_msg "Vault container successfully running"
 }
 
 __execute_vault_bootstrap() {


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/47

- Makes sure the db container is running before completing the db install step

Tested for a db container that came up immediately, a db container that never came up, and for one that came up mid-way through the timeout interval