### PR TITLE
Add GET db route; ensure that api routes load correctly

### DIFF
--- a/admiral.app.js
+++ b/admiral.app.js
@@ -165,9 +165,15 @@ function _initializeRoutes(bag, next) {
 
   glob.sync('./api/**/*Routes.js').forEach(
     function (routeFile) {
-      require(routeFile)(bag.app);
+      if (routeFile !== './api/Routes.js') {
+        require(routeFile)(bag.app);
+      }
     }
   );
+
+  // Require www routes last, so the api routes aren't
+  // overridden by the www redirect
+  require('./api/Routes.js')(bag.app);
 
   return next();
 }

--- a/api/db/Routes.js
+++ b/api/db/Routes.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = dbRoutes;
+var validateAccount = require('../../common/auth/validateAccount.js');
+
+function dbRoutes(app) {
+  app.get('/api/db', validateAccount, require('./get.js'));
+}

--- a/api/db/get.js
+++ b/api/db/get.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var self = get;
+module.exports = self;
+
+var async = require('async');
+var _ = require('underscore');
+
+function get(req, res) {
+  var bag = {
+    reqQuery: req.query,
+    resBody: {
+      ipAddress: '',
+      dbPort: '',
+      dbName: '',
+      dbUser: '',
+      dbPassword: ''
+    }
+  };
+
+  bag.who = util.format('db|%s', self.name);
+  logger.info(bag.who, 'Starting');
+
+  async.series([
+    _checkInputParams.bind(null, bag),
+    _get.bind(null, bag)
+  ],
+    function (err) {
+      logger.info(bag.who, 'Completed');
+      if (err)
+        return respondWithError(res, err);
+
+      sendJSONResponse(res, bag.resBody);
+    }
+  );
+}
+
+function _checkInputParams(bag, next) {
+  var who = bag.who + '|' + _checkInputParams.name;
+  logger.verbose(who, 'Inside');
+
+  return next();
+}
+
+function _get(bag, next) {
+  var who = bag.who + '|' + _get.name;
+  logger.verbose(who, 'Inside');
+
+
+  bag.resBody = {
+    ipAddress: process.env.DBHOST || '',
+    dbPort: process.env.DBPORT || '',
+    dbName: process.env.DBNAME || '',
+    dbUser: process.env.DBUSERNAME || '',
+    dbPassword: process.env.DBPASSWORD || ''
+  };
+
+  return next();
+}

--- a/api/systemConfigs/Routes.js
+++ b/api/systemConfigs/Routes.js
@@ -1,8 +1,8 @@
 'use strict';
 
-module.exports = systemCodeRoutes;
+module.exports = systemConfigRoutes;
 var validateAccount = require('../../common/auth/validateAccount.js');
 
-function systemCodeRoutes(app) {
+function systemConfigRoutes(app) {
   app.get('/api/systemConfigs', validateAccount, require('./getS.js'));
 }

--- a/api/vault/Routes.js
+++ b/api/vault/Routes.js
@@ -4,6 +4,6 @@ module.exports = vaultRoutes;
 var validateAccount = require('../../common/auth/validateAccount.js');
 
 function vaultRoutes(app) {
-  app.get('/api/vault', validateAccount, require('./getS.js'));
+  app.get('/api/vault', validateAccount, require('./get.js'));
   app.post('/api/vault', validateAccount, require('./post.js'));
 }

--- a/api/vault/get.js
+++ b/api/vault/get.js
@@ -1,15 +1,15 @@
 'use strict';
 
-var self = getS;
+var self = get;
 module.exports = self;
 
 var async = require('async');
 var _ = require('underscore');
 
-function getS(req, res) {
+function get(req, res) {
   var bag = {
     reqQuery: req.query,
-    resBody: [],
+    resBody: {},
     initializeDefault: false,
     defaultConfig: {
       address: '127.0.0.1.foo',
@@ -29,7 +29,7 @@ function getS(req, res) {
 
   async.series([
     _checkInputParams.bind(null, bag),
-    _getS.bind(null, bag),
+    _get.bind(null, bag),
     _setDefault.bind(null, bag)
   ],
     function (err) {
@@ -49,8 +49,8 @@ function _checkInputParams(bag, next) {
   return next();
 }
 
-function _getS(bag, next) {
-  var who = bag.who + '|' + _getS.name;
+function _get(bag, next) {
+  var who = bag.who + '|' + _get.name;
   logger.verbose(who, 'Inside');
 
   global.config.client.query('SELECT vault from "systemConfigs"',
@@ -63,7 +63,7 @@ function _getS(bag, next) {
           logger.debug('Found vault configuration');
 
           var vaultConfig = systemConfigs.rows[0].vault;
-          bag.resBody = [JSON.parse(vaultConfig)];
+          bag.resBody = JSON.parse(vaultConfig);
       } else {
         logger.debug('No vault configuration present in configs');
         bag.initializeDefault = true;
@@ -93,7 +93,7 @@ function _setDefault(bag, next) {
         logger.debug('Successfully added default value for vault server');
         bag.resBody = [JSON.parse(vaultDefault)];
       } else {
-        logger.warn('Failed to det default vault server value');
+        logger.warn('Failed to get default vault server value');
       }
 
       return next();


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/30

- Adds the GET db route
- Requires the file with www routes in it after the api routes are required; this ensures that the api routes are initialized correctly
- Fix typos and filenames in GET /api/vault and the systemConfigs routes; GET /api/vault now returns an object, instead of an array