### PR TITLE
#56; use Docker install scripts from matching Node tag.

### DIFF
--- a/common/scripts/docker/installDb.sh
+++ b/common/scripts/docker/installDb.sh
@@ -64,12 +64,13 @@ __check_db() {
   local db_booted=false
 
   while [ $db_booted != true ] && [ $counter -lt $db_timeout ]; do
-    local db_container=$(sudo docker ps | grep $COMPONENT | awk '{print $1}')
-    if [ "$db_container" != "" ]; then
-      __process_msg "Database container found"
+    local database_found=$(nmap -Pn --open -p $DB_PORT $DB_IP | \
+      grep "$DB_PORT/tcp");
+    if [ "$database_found" != "" ]; then
+      __process_msg "Database found"
       db_booted=true
     else
-      __process_msg "Waiting for database container"
+      __process_msg "Waiting for database to start"
       let "counter = $counter + $interval"
       sleep $interval
     fi

--- a/lib/_helpers.sh
+++ b/lib/_helpers.sh
@@ -48,9 +48,9 @@ __check_dependencies() {
     echo 'readonly BUILD_LOCATION="/build"' >> installDockerScript.sh
 
     # Fetch the installation script and headers
-    curl https://raw.githubusercontent.com/Shippable/node/master/lib/logger.sh >> installDockerScript.sh
-    curl https://raw.githubusercontent.com/Shippable/node/master/lib/headers.sh >> installDockerScript.sh
-    curl https://raw.githubusercontent.com/Shippable/node/master/scripts/Ubuntu_14.04_Docker_1.13.sh >> installDockerScript.sh
+    curl https://raw.githubusercontent.com/Shippable/node/$RELEASE/lib/logger.sh >> installDockerScript.sh
+    curl https://raw.githubusercontent.com/Shippable/node/$RELEASE/lib/headers.sh >> installDockerScript.sh
+    curl https://raw.githubusercontent.com/Shippable/node/$RELEASE/scripts/Ubuntu_14.04_Docker_1.13.sh >> installDockerScript.sh
     # Install Docker
     chmod +x installDockerScript.sh
     ./installDockerScript.sh


### PR DESCRIPTION
#56 

Uses `$RELEASE` to get the scripts for Docker installation.  And checks that the database container is running by checking that the port is open so that Postgres will actually be available in the next step.