### PR TITLE
#69; check if the database is ready with nc.

### DIFF
--- a/common/scripts/docker/installDb.sh
+++ b/common/scripts/docker/installDb.sh
@@ -64,9 +64,7 @@ __check_db() {
   local db_booted=false
 
   while [ $db_booted != true ] && [ $counter -lt $db_timeout ]; do
-    local database_found=$(nmap -Pn --open -p $DB_PORT $DB_IP | \
-      grep "$DB_PORT/tcp");
-    if [ "$database_found" != "" ]; then
+    if nc -vz $DB_IP $DB_PORT &>/dev/null; then
       __process_msg "Database found"
       db_booted=true
     else


### PR DESCRIPTION
#69 

Replaces `nmap` with `nc`.  Tested on a new Digital Ocean droplet.  The script waited and then successfully ran the database script.