### PR TITLE
#72; set DB_INSTALLED in admiral.env.

### DIFF
--- a/common/scripts/configs/admiral.env.template
+++ b/common/scripts/configs/admiral.env.template
@@ -10,5 +10,6 @@ DB_USER="apiuser"
 DB_NAME="shipdb"
 DB_PASSWORD=""
 DB_DIALECT="postgres"
+DB_INSTALLED=false
 RUN_MODE="dev"
 SYSTEM_IMAGE_REGISTRY="374168611083.dkr.ecr.us-east-1.amazonaws.com"

--- a/common/scripts/docker/installDb.sh
+++ b/common/scripts/docker/installDb.sh
@@ -108,15 +108,20 @@ __run_db() {
 
     eval "$run_cmd"
     __check_db
+    sed -i 's/.*DB_INSTALLED=.*/DB_INSTALLED=true/g' $ADMIRAL_ENV
   fi
 }
 
 main() {
   __process_marker "Booting database"
-  __validate_db_envs
-  __validate_db_mounts
-  __run_db
-  __process_msg "Database container successfully running"
+  if [ "$DB_INSTALLED" == true ]; then
+    __process_msg "Database already installed, skipping"
+  else
+    __validate_db_envs
+    __validate_db_mounts
+    __run_db
+    __process_msg "Database container successfully running"
+  fi
 }
 
 main


### PR DESCRIPTION
#72 

Tested by removing the database container and rerunning the installer.  It assumed that it would be there and failed.