### PR TITLE
Remove previously-created config and runtime dirs on new install

### DIFF
--- a/admiral.sh
+++ b/admiral.sh
@@ -49,6 +49,7 @@ source "$LIB_DIR/_helpers.sh"
 source "$LIB_DIR/_parseArgs.sh"
 
 main() {
+  __check_dirs
   __check_logsdir
   __parse_args "$@"
   __check_dependencies

--- a/lib/_helpers.sh
+++ b/lib/_helpers.sh
@@ -3,6 +3,23 @@
 # Helper methods ##########################################
 ###########################################################
 
+# TODO: break up this file into smaller, logically-grouped
+# files after we add release and re-install features
+
+__check_dirs() {
+  if [ -d $CONFIG_DIR ]; then
+    __process_msg "Removing previously created $CONFIG_DIR"
+    rm -rf $CONFIG_DIR
+  fi
+  mkdir -p $CONFIG_DIR
+
+  if [ -d $RUNTIME_DIR ]; then
+    __process_msg "Removing previously created $RUNTIME_DIR"
+    rm -rf $RUNTIME_DIR
+  fi
+  mkdir -p $RUNTIME_DIR
+}
+
 __check_dependencies() {
   __process_marker "Checking dependencies"
 


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/68

- Removes the CONFIG_DIR (/etc/shippable) and RUNTIME_DIR (/var/run/shippable) and re-creates them on a new install.