### PR TITLE
add install panels and call db post

### DIFF
--- a/api/db/Routes.js
+++ b/api/db/Routes.js
@@ -5,6 +5,5 @@ var validateAccount = require('../../common/auth/validateAccount.js');
 
 function dbRoutes(app) {
   app.get('/api/db', validateAccount, require('./get.js'));
-  app.post('/api/db/initialize', validateAccount,
-    require('./postInitialize.js'));
+  app.post('/api/db', validateAccount, require('./post.js'));
 }

--- a/api/db/post.js
+++ b/api/db/post.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var self = postInitialize;
+var self = post;
 module.exports = self;
 
 var async = require('async');
@@ -9,7 +9,7 @@ var uuid = require('node-uuid');
 
 var envHandler = require('../../common/envHandler.js');
 
-function postInitialize(req, res) {
+function post(req, res) {
   var bag = {
     reqQuery: req.query,
     resBody: {},

--- a/static/scripts/dashboard/system/install/install.html
+++ b/static/scripts/dashboard/system/install/install.html
@@ -1,0 +1,86 @@
+<div>
+  <div class="col-md-offset-1 col-md-10">
+    <div class="panel-group">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title">
+            <a data-toggle="collapse" href="#initpanel">1. Initialize</a>
+          </h3>
+        </div>
+        <div id="initpanel" class="panel-collapse collapse in">
+          <div class="panel-body">
+            <div ng-if="!vm.isLoaded">
+              Loading...
+            </div>
+            <div class="col-md-offset-1 col-md-10">
+              <div ng-if="vm.isLoaded && !vm.dbInitialized && !vm.initializing" class="row">
+                <button class="btn btn-md btn-primary" type="submit" ng-disabled="vm.initializing" ng-click="vm.initialize()">
+                  Initialize
+                </button>
+              </div>
+              <div ng-if="vm.isLoaded && (vm.dbInitialized || vm.initializing)" class="row">
+                <table class="table table-condensed table-striped">
+                  <thead>
+                    <tr>
+                      <th></th>
+                      <th></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>
+                        <b>Database:</b>
+                      </td>
+                      <td>
+                        {{vm.dbInitialized ? 'initialized' : 'checking status'}}
+                      </td>
+                      <td>
+                        <button class="btn btn-sm btn-default" ng-disabled="!vm.dbInitialized">config</button>
+                        <button class="btn btn-sm btn-default" ng-disabled="!vm.dbInitialized">logs</button>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td colspan=3>
+                        <button class="btn btn-md btn-primary" type="submit" ng-disabled="vm.initializing" ng-click="vm.initialize()">
+                          <div ng-if="vm.initializing">
+                            initializing...
+                          </div>
+                          <div ng-if="!vm.initializing">
+                            Re-initialize
+                          </div>
+                        </button>
+                      </td>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title">
+            <a data-toggle="collapse" href="#installpanel">2. Install</a>
+          </h3>
+        </div>
+        <div id="installpanel" class="panel-collapse collapse">
+          <div class="panel-body">
+            test data
+          </div>
+        </div>
+      </div>
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title">
+            <a data-toggle="collapse" href="#addonpanel">3. Add-ons</a>
+          </h3>
+        </div>
+        <div id="addonpanel" class="panel-collapse collapse">
+          <div class="panel-body">
+            test data
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/static/scripts/dashboard/system/install/installCtrl.js
+++ b/static/scripts/dashboard/system/install/installCtrl.js
@@ -1,0 +1,89 @@
+(function () {
+  'use strict';
+
+  admiral.controller('dashboard.installCtrl', ['$scope', '$stateParams', '$q',
+    '$state', 'admiralApiAdapter', 'horn',
+    installCtrl
+  ])
+  .config(['$stateProvider', 'SRC_PATH',
+    function ($stateProvider, SRC_PATH) {
+      $stateProvider.state('dashboard.system.install', {
+        url: '/install',
+        templateUrl: SRC_PATH + 'dashboard/system/install/install.html',
+        controller: 'dashboard.installCtrl'
+      });
+    }
+  ]);
+
+
+  function installCtrl($scope, $stateParams, $q, $state, admiralApiAdapter,
+    horn) {
+    $scope._r.title = 'System | Install - Admiral';
+    $scope.vm = {
+      isLoaded: false,
+      initializing: false,
+      initialize: initialize
+    };
+
+    $scope._r.appPromise.then(initWorkflow);
+
+    function initWorkflow() {
+      var bag = {};
+      async.series([
+          getSystemConfigs.bind(null, bag)
+        ],
+        function (err) {
+          $scope.vm.isLoaded = true;
+          if (err)
+            return horn.error(err);
+          $scope.vm.systemConfigs = bag.systemConfigs;
+        }
+      );
+    }
+
+    function getSystemConfigs(bag, next) {
+      admiralApiAdapter.getSystemConfigs(
+        function (err, systemConfigs) {
+          if (err)
+            return next(err);
+
+          bag.systemConfigs = systemConfigs;
+          bag.dbStatus = systemConfigs.db;
+
+          if (bag.dbStatus && bag.dbStatus.initialized === 'true')
+            $scope.vm.dbInitialized = true;
+
+          return next();
+        }
+      );
+    }
+    function initialize() {
+      $scope.vm.initializing = true;
+      var bag = {};
+      async.series([
+          initializeDatabase.bind(null, bag),
+          getSystemConfigs.bind(null, bag)
+        ],
+        function (err) {
+          $scope.vm.initializing = false;
+          if (err) {
+            console.log(err);
+            return;
+          }
+          $scope.vm.systemConfigs = bag.systemConfigs;
+        }
+      );
+    }
+    function initializeDatabase(bag, next) {
+
+      admiralApiAdapter.postDatabase({},
+        function (err) {
+          // set to true regardless until actual functionality is added
+          $scope.vm.dbInitialized = true;
+          return next(err);
+        }
+      );
+    }
+
+  }
+}());

--- a/static/scripts/dashboard/system/system.html
+++ b/static/scripts/dashboard/system/system.html
@@ -2,6 +2,9 @@
   <div class="col-md-2 col-xs-3 well">
     <ul class="nav nav-tabs nav-stacked">
       <li ui-sref-active="active" class="active">
+        <a ui-sref="dashboard.system.install" ui-sref-opts="{reload: true}">Install</a>
+      </li>
+      <li ui-sref-active="active">
         <a ui-sref="dashboard.system.database" ui-sref-opts="{reload: true}">Database</a>
       </li>
       <li ui-sref-active="active">

--- a/static/scripts/services/admiralApiAdapter.js
+++ b/static/scripts/services/admiralApiAdapter.js
@@ -27,6 +27,9 @@
       getDatabase: function (callback) {
         return API.get('/api/db', callback);
       },
+      postDatabase: function (body, callback) {
+        return API.post('/api/db', body, callback);
+      },
       getVault: function (callback) {
         return API.get('/api/vault', callback);
       },


### PR DESCRIPTION
#82 

- starts by just showing initialize button
- clicking button calls `POST /api/db/`
- for now, dbIntialized is set to true after clicking, since back end doesnt set the systemConfig yet
- dbInitialized also set to true if the systemConfigs flag is set to true (systemConfigs.db.intiialized)
- when initialization is complete, user can click 're-initialize' to call the post db route again
- added empty panels for the other two sections.
- config/log buttons don't do anything yet.
- panels are collapsable. panel 1 starts expanded, the others start out collapsed


![image](https://cloud.githubusercontent.com/assets/6869398/24886574/7d964fea-1e0a-11e7-8c7c-4f7680d0a228.png)

![image](https://cloud.githubusercontent.com/assets/6869398/24886581/8b5e06d6-1e0a-11e7-92cb-3019d9bd9d96.png)

![image](https://cloud.githubusercontent.com/assets/6869398/24886591/96e1ce52-1e0a-11e7-8799-21427bfa7b90.png)
