### PR TITLE
add gitlab to table and rearrange the UI a bit. also surface errors

### DIFF
--- a/api/msg/post.js
+++ b/api/msg/post.js
@@ -169,7 +169,12 @@ function _initializeMsg(bag, next) {
 
   exec.on('close',
     function (exitCode)  {
-      return next(exitCode);
+      if (exitCode > 0)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'Script returned code: ' + exitCode)
+        );
+      return next();
     }
   );
 }

--- a/api/redis/post.js
+++ b/api/redis/post.js
@@ -158,7 +158,12 @@ function _initializeRedis(bag, next) {
 
   exec.on('close',
     function (exitCode)  {
-      return next(exitCode);
+      if (exitCode > 0)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'Script returned code: ' + exitCode)
+        );
+      return next();
     }
   );
 }

--- a/api/secrets/post.js
+++ b/api/secrets/post.js
@@ -170,7 +170,12 @@ function _initializeVault(bag, next) {
 
   exec.on('close',
     function (exitCode)  {
-      return next(exitCode);
+      if (exitCode > 0)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'Script returned code: ' + exitCode)
+        );
+      return next();
     }
   );
 }

--- a/api/state/post.js
+++ b/api/state/post.js
@@ -164,7 +164,12 @@ function _initializeState(bag, next) {
 
   exec.on('close',
     function (exitCode)  {
-      return next(exitCode);
+      if (exitCode > 0)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'Script returned code: ' + exitCode)
+        );
+      return next();
     }
   );
 }

--- a/api/workflow/initialize.js
+++ b/api/workflow/initialize.js
@@ -68,7 +68,8 @@ function _initializeDatabase(bag, next) {
     function (err) {
       if (err)
         return next(
-          new ActErr(who, err.id || ActErr.OperationFailed, err)
+          new ActErr(who, err.id || ActErr.OperationFailed,
+            'Failed to initialize database.', err)
         );
 
       return next();
@@ -84,7 +85,8 @@ function _getSecrets(bag, next) {
     function (err, secrets) {
       if (err)
         return next(
-          new ActErr(who, err.id || ActErr.OperationFailed, err)
+          new ActErr(who, err.id || ActErr.OperationFailed,
+            'Failed to fetch secrets information', err)
         );
       bag.secretsInitialized =
         secrets && secrets.isInstalled && secrets.isInitialized;
@@ -103,7 +105,8 @@ function _initializeSecrets(bag, next) {
     function (err) {
       if (err)
         return next(
-          new ActErr(who, err.id || ActErr.OperationFailed, err)
+          new ActErr(who, err.id || ActErr.OperationFailed,
+            'Failed to initialize secrets provider', err)
         );
 
       return next();
@@ -119,7 +122,8 @@ function _getMsg(bag, next) {
     function (err, msg) {
       if (err)
         return next(
-          new ActErr(who, err.id || ActErr.OperationFailed, err)
+          new ActErr(who, err.id || ActErr.OperationFailed,
+            'Failed to get message information', err)
         );
 
       bag.msgInitialized = msg && msg.isInstalled && msg.isInitialized;
@@ -143,7 +147,8 @@ function _initializeMsg(bag, next) {
     function (err) {
       if (err)
         return next(
-          new ActErr(who, err.id || ActErr.OperationFailed, err)
+          new ActErr(who, err.id || ActErr.OperationFailed,
+            'Failed to initialize messaging provider', err)
         );
 
       return next();
@@ -159,7 +164,8 @@ function _getState(bag, next) {
     function (err, state) {
       if (err)
         return next(
-          new ActErr(who, err.id || ActErr.OperationFailed, err)
+          new ActErr(who, err.id || ActErr.OperationFailed,
+            'Failed to get state information', err)
         );
 
       bag.stateInitialized = state && state.isInstalled && state.isInitialized;
@@ -183,7 +189,8 @@ function _initializeState(bag, next) {
     function (err) {
       if (err)
         return next(
-          new ActErr(who, err.id || ActErr.OperationFailed, err)
+          new ActErr(who, err.id || ActErr.OperationFailed,
+            'Failed to initialize state provider', err)
         );
 
       return next();

--- a/static/scripts/dashboard/dashboard.html
+++ b/static/scripts/dashboard/dashboard.html
@@ -19,27 +19,23 @@
               <div ng-if="!vm.isLoaded">
                 Loading...
               </div>
-              <div class="col-md-offset-1 col-md-10">
-                <div ng-if="vm.isLoaded && !vm.initializing &&
-                  (!vm.dbInitialized || !vm.msgInitialized || !vm.stateInitialized || !vm.secretsInitialized)"
+              <div class="col-md-offset-1 col-md-10" ng-if="vm.isLoaded">
+                <div ng-if="!vm.msgInitialized"
                   class="row">
                   <span class="col-md-7">Choose a password for RabbitMQ (the message bus):</span>
                   <div class="col-md-5">
                     <input type="text" class="form-control" name="msgPassword"
-                    ng-model="vm.initializeForm.msgPassword"/>
+                    ng-model="vm.initializeForm.msgPassword" ng-disabled="vm.isInitializing"/>
                   </div>
+                </div>
+                <div ng-if="!vm.stateInitialized" class="row">
                   <span class="col-md-7">Choose a password for Gitlab (this stores job state):</span>
                   <div class="col-md-5">
                     <input type="text" class="form-control" name="statePassword"
-                    ng-model="vm.initializeForm.statePassword"/>
+                    ng-model="vm.initializeForm.statePassword" ng-disabled="vm.isInitializing"/>
                   </div>
                 </div>
-                <div class="col-md-12 text-right">
-                  <button class="btn btn-md btn-primary" type="submit" ng-disabled="vm.initializing || !vm.initializeForm.msgPassword || !vm.initializeForm.statePassword" ng-click="vm.initialize()">
-                    Initialize
-                  </button>
-                </div>
-                <div ng-if="vm.isLoaded && ((vm.dbInitialized && vm.msgInitialized && vm.stateInitialized) || vm.initializing)" class="row">
+                <div class="row">
                   <table class="table table-condensed table-striped">
                     <thead>
                       <tr>
@@ -53,7 +49,7 @@
                           <b>Database:</b>
                         </td>
                         <td>
-                          {{vm.dbInitialized ? 'initialized' : 'checking status'}}
+                          {{vm.dbInitialized ? 'initialized' : 'not initialzed'}}
                         </td>
                         <td>
                           <button class="btn btn-sm btn-default" ng-disabled="!vm.dbInitialized">config</button>
@@ -86,6 +82,18 @@
                       </tr>
                       <tr>
                         <td>
+                          <b>State:</b>
+                        </td>
+                        <td>
+                          {{vm.stateInitialized ? 'initialized' : 'not initialized'}}
+                        </td>
+                        <td>
+                          <button class="btn btn-sm btn-default" ng-disabled="!vm.stateInitialized">config</button>
+                          <button class="btn btn-sm btn-default" ng-disabled="!vm.stateInitialized">logs</button>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
                           <b>Redis:</b>
                         </td>
                         <td>
@@ -98,15 +106,23 @@
                       </tr>
                       <tr>
                         <td colspan=3>
-                          <button class="btn btn-md btn-primary" type="submit" ng-disabled="vm.initializing || !vm.dbInitialized || !vm.msgInitialized || !vm.rdsInitialized" ng-click="vm.initialize()">
+                          <button class="btn btn-md btn-primary" type="submit" ng-disabled="vm.initializing" ng-click="vm.initialize()">
                             <div ng-if="vm.initializing">
                               initializing...
                             </div>
                             <div ng-if="!vm.initializing">
-                              Re-initialize
+                              Initialize
                             </div>
                           </button>
                         </td>
+                      </tr>
+                      <tr ng-if="vm.initializeResponse">
+                        <td colspan=3>
+                          <div class="alert alert-danger">
+                            {{vm.initializeResponse}}
+                          </div>
+                        </td>
+                      </tr>
                     </tbody>
                   </table>
                 </div>

--- a/static/scripts/dashboard/dashboardCtrl.js
+++ b/static/scripts/dashboard/dashboardCtrl.js
@@ -28,12 +28,14 @@
       initializing: false,
       dbInitialized: false,
       secretsInitialized: false,
+      stateInitialized: false,
       msgInitialized: false,
       rdsInitialized: false,
       initializeForm: {
         msgPassword: '',
         statePassword: ''
       },
+      initializeResponse: '',
       initialize: initialize,
       logOutOfAdmiral: logOutOfAdmiral
     };
@@ -96,7 +98,7 @@
 
           $scope.vm.secretsInitialized =
             bag.secretsStatus && bag.secretsStatus.isInitialized;
-            
+
           $scope.vm.msgInitialized =
             bag.msgStatus && bag.msgStatus.isInitialized;
           $scope.vm.initializeForm.msgPassword =
@@ -135,7 +137,9 @@
     function postInitialize(bag, next) {
       admiralApiAdapter.postInitialize($scope.vm.initializeForm,
         function (err) {
-          return next(err);
+          if (err)
+            $scope.vm.initializeResponse = err.methodName + ': ' + err.message;
+          return next();
         }
       );
     }


### PR DESCRIPTION
#100

- table always displayed
- single 'initialize' button
- input fields are hidden once their respective service is successfully 'intiailzed'
- error messages from initialize route are shown in the table below the button.
- updated POST routes to return a better error when the script fails.
- updated init route to return ActErr correctly

![image](https://cloud.githubusercontent.com/assets/6869398/24971853/3a8d2812-1f6e-11e7-8f20-c235fba9a474.png)
