### PR TITLE
always pull admiral, and use built-in clean

### DIFF
--- a/common/scripts/boot_admiral.sh
+++ b/common/scripts/boot_admiral.sh
@@ -34,6 +34,13 @@ __boot_admiral() {
 
     local admiral_image="$PUBLIC_IMAGE_REGISTRY/admiral:$RELEASE"
 
+    local pull_cmd="sudo docker pull $admiral_image"
+
+    __process_msg "Executing: $pull_cmd"
+
+    eval "$pull_cmd"
+    __process_msg "Admiral image successfully pulled"
+
     local boot_cmd="sudo docker run -d \
       $envs \
       $mounts \

--- a/common/scripts/lib/_parseArgs.sh
+++ b/common/scripts/lib/_parseArgs.sh
@@ -191,12 +191,7 @@ __wipe_clean() {
     else
       __process_msg "No containers found. Skipping removal."
     fi
-    local remove_mnts_cmd="sudo rm -rf /var/run/shippable"
-    __process_msg "Executing: $remove_mnts_cmd"
-    eval "$remove_mnts_cmd"
-    local remove_configs_cmd="sudo rm -rf /etc/shippable"
-    __process_msg "Executing: $remove_configs_cmd"
-    eval "$remove_configs_cmd"
+    __cleanup
     __process_success "Clean is complete. Reinstall by running 'sudo ./admiral.sh install'"
     exit 0
   else


### PR DESCRIPTION
#185

also modified cleanup to use the 'helper' script that already existed. 
https://github.com/Shippable/admiral/blob/master/common/scripts/lib/_helpers.sh#L9