### PR TITLE
dont return error if sysconfigs arent added yet

### DIFF
--- a/api/systemConfigs/get.js
+++ b/api/systemConfigs/get.js
@@ -41,10 +41,15 @@ function _get(bag, next) {
 
   global.config.client.query('SELECT * from "systemConfigs"',
     function (err, systemConfigs) {
-      if (err)
+      if (err) {
+        if (err.code === '42P01') {
+          logger.debug('SystemConfigs table not created. Please initialize.');
+          return next();
+        }
         return next(
-          new ActErr(who, ActErr.DataNotFound, err)
+          new ActErr(who, ActErr.DBOperationFailed, err)
         );
+      }
 
       if (!systemConfigs.rows || !systemConfigs.rows[0])
         return next(

--- a/static/scripts/dashboard/dashboardCtrl.js
+++ b/static/scripts/dashboard/dashboardCtrl.js
@@ -93,9 +93,10 @@
     function getSystemConfigs(bag, next) {
       admiralApiAdapter.getSystemConfigs(
         function (err, systemConfigs) {
-          if (err || !systemConfigs) {
-            // the route will return an error when
-            // the db hasn't been initialized yet
+          if (err)
+            return next(err);
+          if (_.isEmpty(systemConfigs)) {
+            // if empty, we can't do anything yet
             return next();
           }
 


### PR DESCRIPTION
#186

if the systemConfigs query returns the error code that means the relation doesn't even exist yet, we will just return an empty object instead of throwing an error, since this means that just haven't clicked 'initialize' yet.

Any other error from the query will actually log an error as a DBOperationFailed.

if the query has no error, but no systemConfigs are found, then we return a 404 since this should never happen.