### PR TITLE
Place loginToken in rootScope

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -28,11 +28,11 @@ admiral.config(['$stateProvider', '$locationProvider', '$httpProvider',
 ]);
 
 (function () {
-  admiral.run(['$rootScope', '$timeout', '$q',
+  admiral.run(['$rootScope', '$timeout', '$q', '$cookies',
     startApp
   ]);
 
-  function startApp($rootScope, $timeout, $q) {
+  function startApp($rootScope, $timeout, $q, $cookies) {
     $('#overlay').fadeOut(800);
     // All root variables to be stored in _r
     $rootScope._r = {};
@@ -55,11 +55,15 @@ admiral.config(['$stateProvider', '$locationProvider', '$httpProvider',
       $rootScope._r.title = 'Shippable | Admiral';
       $rootScope._r.appDefer = $q.defer();
       $rootScope._r.appPromise = $rootScope._r.appDefer.promise;
+
       $rootScope._r.appPromise.then(
         function () {
           $rootScope._r.appLoaded = true;
         }
       );
+
+      $rootScope._r.loginToken = $cookies.loginToken;
+
       $timeout(
         function () {
           $rootScope._r.loadingMessage = 'Loading app...';

--- a/static/scripts/login/loginCtrl.js
+++ b/static/scripts/login/loginCtrl.js
@@ -72,6 +72,7 @@
             return horn.error(err);
 
           e.preventDefault();
+          $scope._r.loginToken = loginToken;
           $state.go('dashboard', $state.params);
           window.scrollTo(0, 0);
         }

--- a/static/scripts/services/admiralService.js
+++ b/static/scripts/services/admiralService.js
@@ -11,11 +11,11 @@
    *  is called when the request completes.
    */
 
-  admiral.service('admiralService', ['ADMIRAL_URL', '$http', '$cookies',
+  admiral.service('admiralService', ['ADMIRAL_URL', '$http', '$rootScope',
     admiralService
   ]);
 
-  function admiralService(ADMIRAL_URL, $http, $cookies) {
+  function admiralService(ADMIRAL_URL, $http, $rootScope) {
     function handler(promise, callback) {
       if (callback)
         promise
@@ -34,7 +34,7 @@
 
         var promise = $http.get(ADMIRAL_URL + path, {
           headers: {
-            Authorization: 'apiToken ' + $cookies.loginToken
+            Authorization: 'apiToken ' + $rootScope._r.loginToken
           }
         });
         return handler(promise, callback);
@@ -42,7 +42,7 @@
       put: function (path, body, callback) {
         var promise = $http.put(ADMIRAL_URL + path, body, {
           headers: {
-            Authorization: 'apiToken ' + $cookies.loginToken
+            Authorization: 'apiToken ' + $rootScope._r.loginToken
           }
         });
         return handler(promise, callback);
@@ -50,7 +50,7 @@
       post: function (path, body, callback) {
         var promise = $http.post(ADMIRAL_URL + path, body, {
           headers: {
-            Authorization: 'apiToken ' + $cookies.loginToken
+            Authorization: 'apiToken ' + $rootScope._r.loginToken
           }
         });
         return handler(promise, callback);
@@ -58,7 +58,7 @@
       delete: function (path, callback) {
         var promise = $http.delete(ADMIRAL_URL + path, {
           headers: {
-            Authorization: 'apiToken ' + $cookies.loginToken
+            Authorization: 'apiToken ' + $rootScope._r.loginToken
           }
         });
         return handler(promise, callback);


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/198

- By putting the token in rootScope, the first call from the dashboardCtrl no longer gets an auth error. The error happened because the controller was trying to make the systemConfigs call before the token had been saved in the cookie.