### PR TITLE
#232; fixes DtTm column names.

### DIFF
--- a/common/scripts/configs/system_settings.sql
+++ b/common/scripts/configs/system_settings.sql
@@ -35,8 +35,8 @@ do $$
         "redis" TEXT,
         "master" TEXT,
         "workers" TEXT,
-        "mktgPageAggsLastDtTime" timestamp with time zone,
-        "mktgCTAAggsLastDtTime" timestamp with time zone,
+        "mktgPageAggsLastDtTm" timestamp with time zone,
+        "mktgCTAAggsLastDtTm" timestamp with time zone,
         "defaultMinionInstanceSize" VARCHAR(255),
         "createdAt" timestamp with time zone NOT NULL,
         "updatedAt" timestamp with time zone NOT NULL


### PR DESCRIPTION
#232 

Checked the database on reinstalling.  The column names were correct.