### PR TITLE
#260; saves unseal keys.

### DIFF
--- a/api/secrets/post.js
+++ b/api/secrets/post.js
@@ -269,12 +269,11 @@ function _post(bag, next) {
   var who = bag.who + '|' + _post.name;
   logger.verbose(who, 'Inside');
 
-  var update = {
-    isInstalled: true,
-    isInitialized: true
-  };
+  // The keys have been added to bag.config
+  bag.config.isInstalled = true;
+  bag.config.isInitialized = true;
 
-  configHandler.put(bag.component, update,
+  configHandler.put(bag.component, bag.config,
     function (err) {
       if (err)
         return next(


### PR DESCRIPTION
#260 

The rootToken and unsealKeys had been added to `bag.config`, but only `isInstalled` and `isInitialized` were being updated.