### PR TITLE
Show core services in install panel

### DIFF
--- a/static/scripts/dashboard/dashboard.html
+++ b/static/scripts/dashboard/dashboard.html
@@ -155,7 +155,7 @@
                         <td colspan=3 class="text-right">
                           <button class="btn btn-md btn-primary" type="submit" ng-disabled="vm.initializing" ng-click="vm.initialize()">
                             <div ng-if="vm.initializing">
-                              initializing...
+                              Initializing...
                             </div>
                             <div ng-if="!vm.initializing">
                               Initialize
@@ -442,9 +442,46 @@
                           {{setting.name}}
                         </div>
                         <div class="col-md-9">
-                          <input type="{{setting.type}}" class="form-control" name="settings{{key}}"
+                          <input type="{{setting.type}}" ng-class="{'form-control': setting.type !== 'checkbox'}"  name="settings{{key}}"
                             ng-model="setting.value" ng-disabled="vm.installing"/>
                         </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="col-md-10">
+                  &nbsp;
+                  <p>
+                    Core services to be installed:
+                  </p>
+                </div>
+                <div class="col-md-offset-1 col-md-10">
+                  <div class="row">
+                    <div class="col-md-offset-2 col-md-10">
+                      <div class="row">
+                        <table class="table table-condensed table-striped">
+                          <thead>
+                          </thead>
+                          <tbody>
+                            <tr ng-repeat="service in vm.coreServices">
+                              <td>
+                                <b>{{service.serviceName}}</b>
+                              </td>
+                              <td>
+                              </td>
+                              <td>
+                              </td>
+                              <td>
+                              </td>
+                              <td class="text-right">
+                                Replicas:
+                              </td>
+                              <td>
+                                {{service.replicas}}
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
                       </div>
                     </div>
                   </div>
@@ -458,7 +495,7 @@
                   </p>
                   <button class="btn btn-md btn-primary" type="submit" ng-disabled="vm.installing" ng-click="vm.install()">
                     <div ng-if="vm.installing">
-                      installing...
+                      Installing...
                     </div>
                     <div ng-if="!vm.installing">
                       Install

--- a/static/scripts/dashboard/dashboardCtrl.js
+++ b/static/scripts/dashboard/dashboardCtrl.js
@@ -93,7 +93,8 @@
             url: ''
           }
         },
-        systemSettings: []
+        systemSettings: [],
+        coreServices: []
       },
       systemSettings: {
         db: {
@@ -137,7 +138,8 @@
           getAdmiralEnv.bind(null, bag),
           setupSystemIntDefaults.bind(null, bag),
           getSystemIntegrations.bind(null, bag),
-          getSystemSettingsForInstallPanel.bind(null, bag)
+          getSystemSettingsForInstallPanel.bind(null, bag),
+          getServices.bind(null, bag)
         ],
         function (err) {
           $scope.vm.isLoaded = true;
@@ -465,6 +467,25 @@
           });
 
           $scope.vm.installForm.systemSettings = settings;
+
+          return next();
+        }
+      );
+    }
+
+    function getServices(bag, next) {
+      admiralApiAdapter.getServices('',
+        function (err, services) {
+          if (err) {
+            horn.error(err);
+            return next();
+          }
+
+          $scope.vm.coreServices = _.filter(services,
+            function (service) {
+              return service.isCore;
+            }
+          );
 
           return next();
         }

--- a/static/scripts/services/admiralApiAdapter.js
+++ b/static/scripts/services/admiralApiAdapter.js
@@ -56,6 +56,10 @@
       getService: function(component, callback) {
         return API.get('/api/' + component, callback);
       },
+      // Services Routes
+      getServices: function (query, callback) {
+        return API.get('/api/services?' + query, callback);
+      },
       // logs
       getServiceLogs: function(component, callback) {
         return API.get('/api/' + component + '/logs', callback);


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/234

Shows the core services in the install panel:

![showcoreservices](https://cloud.githubusercontent.com/assets/7757711/25206429/be8f1112-251c-11e7-83cb-38231757c72a.png)

Also fixes the funky checkbox-in-chrome thing.