### PR TITLE
#285; redirect everything to the dashboard.

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -22,6 +22,8 @@ admiral.config(['$stateProvider', '$locationProvider', '$httpProvider',
       }
     );
 
+    $urlRouterProvider.otherwise('/');
+
     $urlMatcherFactoryProvider.strictMode(false);
     $locationProvider.html5Mode(true);
   }


### PR DESCRIPTION
#285 

Deals with strange URLs by sending them to the dashboard.  The `/login` URL still works as well.