### PR TITLE
Hide password/installer key input boxes on successful initialization

### DIFF
--- a/api/workflow/initialize.js
+++ b/api/workflow/initialize.js
@@ -28,9 +28,9 @@ function initialize(req, res) {
 
   async.series([
       _checkInputParams.bind(null, bag),
-      _sendResponse.bind(null, bag),
       _saveAccessKey.bind(null, bag),
       _saveSecretKey.bind(null, bag),
+      _sendResponse.bind(null, bag),
       _initializeDatabase.bind(null, bag),
       _getSecrets.bind(null, bag),
       _initializeSecrets.bind(null, bag),
@@ -79,16 +79,6 @@ function _checkInputParams(bag, next) {
   return next();
 }
 
-function _sendResponse(bag, next) {
-  var who = bag.who + '|' + _checkInputParams.name;
-  logger.verbose(who, 'Inside');
-
-  // We reply early so the request won't time out pulling images.
-
-  sendJSONResponse(bag.res, bag.resBody);
-  return next();
-}
-
 function _saveAccessKey(bag, next) {
   if (!bag.reqBody.accessKey) return next();
   var who = bag.who + '|' + _saveAccessKey.name;
@@ -127,6 +117,16 @@ function _saveSecretKey(bag, next) {
       return next();
     }
   );
+}
+
+function _sendResponse(bag, next) {
+  var who = bag.who + '|' + _checkInputParams.name;
+  logger.verbose(who, 'Inside');
+
+  // We reply early so the request won't time out pulling images.
+
+  sendJSONResponse(bag.res, bag.resBody);
+  return next();
 }
 
 function _initializeDatabase(bag, next) {

--- a/static/scripts/dashboard/dashboard.html
+++ b/static/scripts/dashboard/dashboard.html
@@ -20,33 +20,33 @@
                 Loading...
               </div>
               <div class="col-md-offset-1 col-md-10" ng-if="vm.isLoaded">
-                <div ng-if="!vm.systemSettings.msg.isInitialized"
+                <div ng-if="!vm.initialized"
                   class="row">
                   <span class="col-md-7">Choose a password for RabbitMQ (the message bus):</span>
                   <div class="col-md-5">
                     <input type="text" class="form-control" name="msgPassword"
-                    ng-model="vm.initializeForm.msgPassword" ng-disabled="vm.initializing"/>
+                    ng-model="vm.initializeForm.msgPassword" ng-disabled="vm.systemSettings.msg.isInitialized || vm.initializing"/>
                   </div>
                 </div>
-                <div ng-if="!vm.systemSettings.state.isInitialized" class="row">
+                <div ng-if="!vm.initialized" class="row">
                   <span class="col-md-7">Choose a password for Gitlab (this stores job state):</span>
                   <div class="col-md-5">
                     <input type="text" class="form-control" name="statePassword"
-                    ng-model="vm.initializeForm.statePassword" ng-disabled="vm.initializing"/>
+                    ng-model="vm.initializeForm.statePassword" ng-disabled="vm.systemSettings.state.isInitialized || vm.initializing"/>
                   </div>
                 </div>
-                <div ng-if="!vm.admiralEnv.ACCESS_KEY" class="row">
+                <div ng-if="!vm.initialized" class="row">
                   <span class="col-md-7">Enter your installer access key:</span>
                   <div class="col-md-5">
                     <input type="text" class="form-control" name="accessKey"
-                    ng-model="vm.initializeForm.accessKey" ng-disabled="vm.initializing"/>
+                    ng-model="vm.initializeForm.accessKey" ng-disabled="vm.admiralEnv.ACCESS_KEY || vm.initializing"/>
                   </div>
                 </div>
-                <div ng-if="!vm.admiralEnv.SECRET_KEY" class="row">
+                <div ng-if="!vm.initialized" class="row">
                   <span class="col-md-7">Enter your installer secret key:</span>
                   <div class="col-md-5">
                     <input type="text" class="form-control" name="secretKey"
-                    ng-model="vm.initializeForm.secretKey" ng-disabled="vm.initializing"/>
+                    ng-model="vm.initializeForm.secretKey" ng-disabled="vm.admiralEnv.SECRET_KEY || vm.initializing"/>
                   </div>
                 </div>
                 <div class="row">

--- a/static/scripts/dashboard/dashboardCtrl.js
+++ b/static/scripts/dashboard/dashboardCtrl.js
@@ -190,10 +190,13 @@
             _.extend($scope.vm.systemSettings.redis,
               (systemSettings.redis && JSON.parse(systemSettings.redis)));
 
-          $scope.vm.initializeForm.msgPassword =
-              $scope.vm.systemSettings.msg.password || '';
-          $scope.vm.initializeForm.statePassword =
-            $scope.vm.systemSettings.state.rootPassword || '';
+          if ($scope.vm.systemSettings.msg.password)
+            $scope.vm.initializeForm.msgPassword =
+              $scope.vm.systemSettings.msg.password;
+
+          if ($scope.vm.systemSettings.state.rootPassword)
+            $scope.vm.initializeForm.statePassword =
+              $scope.vm.systemSettings.state.rootPassword;
 
           $scope.vm.initialized = $scope.vm.systemSettings.db.isInitialized &&
             $scope.vm.systemSettings.secrets.isInitialized &&
@@ -215,6 +218,13 @@
           }
 
           $scope.vm.admiralEnv = admiralEnv;
+
+          if (admiralEnv.ACCESS_KEY)
+            $scope.vm.initializeForm.accessKey = admiralEnv.ACCESS_KEY;
+
+          if (admiralEnv.SECRET_KEY)
+            $scope.vm.initializeForm.secretKey = admiralEnv.SECRET_KEY;
+
           return next();
         }
       );


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/298

- Show/hide the password/installer key input boxes as a block
- Disable them during initialization
- Hide them after successful initialization
- If an init fails, still show them, but keep them disabled (unless something failed before the point the password was saved)
- Send the response from the init route after the access key and secrets have been saved (this keeps the UI from needing to poll for admiralEnvs)

During initialization:
![initializing](https://cloud.githubusercontent.com/assets/7757711/25294190/f08318cc-2692-11e7-847e-d761a9f5c380.png)

Init complete:
![initialized](https://cloud.githubusercontent.com/assets/7757711/25294195/f63e6622-2692-11e7-9441-26564f88dae3.png)

