### PR TITLE
Make bitbucket server client secret input a textarea

### DIFF
--- a/static/scripts/dashboard/dashboard.html
+++ b/static/scripts/dashboard/dashboard.html
@@ -268,8 +268,8 @@
                           Client Secret
                         </div>
                         <div class="col-md-9">
-                          <input type="text" class="form-control" name="bitbucketServerClientSecret"
-                            ng-model="vm.installForm.auth.bitbucketServerKeys.data.clientSecret" ng-disabled="vm.installing"/>
+                          <textarea class="form-control" rows="3" name="bitbucketServerClientSecret" ng-model="vm.installForm.auth.bitbucketServerKeys.data.clientSecret" ng-disabled="vm.installing" placeholder="-----BEGIN ENCRYPTED PRIVATE KEY----- MIIFDjBABgkqhkiG9w0BBQ0wMzAbBgkqhkiG9w0BBQwwDgQIS2qgprFqPxECAggA MBQGCCqGSIb3DQMHBAgD1kGN4ZslJgSCBMi1xk9jhlPxP3FyaMIUq8QmckXCs3Sa 9g73NQbtqZwI+9X5OhpSg/2ALxlCCjbqvzgSu8gfFZ4yo+Xd8VucZDmDSpzZGDod A .... MANY LINES LIKE THAT .... .... MANY LINES LIKE THAT ....  X0R+meOaudPTBxoSgCCM51poFgaqt4l6VlTN4FRpj+c/WZeoMM/BVXO+nayuIMyH blK948UAda/bWVmZjXfY4Tztah0CuqlAldOQBzu8TwE7WDwo5S7lo5u0EXEoqCCq H0ga/iLNvWYexG7FHLRiq5hTj0g9mUPEbeTXuPtOkTEb/0ckVE2iZH9l7g5edmUZ GEs= -----END ENCRYPTED PRIVATE KEY----- -----BEGIN CERTIFICATE----- MIIDXTCCAkWgAwIBAgIJAJC1HiIAZAiIMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX aWRnaXRzIFB0eSBMdGQwHhcNMTExMjMxMDg1OTQ0WhcNMTIxMjMwMDg1OTQ0WjBF A .... MANY LINES LIKE THAT .... .... MANY LINES LIKE THAT ....  JjyzfN746vaInA1KxYEeI1Rx5KXY8zIdj6a7hhphpj2E04LDdw7r495dv3UgEgpR C3Fayua4DRHyZOLmlvQ6tIChY0ClXXuefbmVSDeUHwc8YufRAERp2GfQnL2JlPUL B7xxt8BVc69rLeHV15A0qyx77CLSj3tCx2IUXVqRs5mlSbq094NBxsauYcm0A6Jq vA== -----END CERTIFICATE-----" required/>
+                          </textarea>
                         </div>
                       </div>
                       <div class="row">


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/399

- Changes the bitbucket server client secret input from an input box to a textarea
- Tested by inputing a BBS private key; was able to successfully log in using bbs credentials

![bbssecrettextbox](https://cloud.githubusercontent.com/assets/7757711/25452011/e579c946-2a78-11e7-8268-f2d5e0df18d5.png)
