### PR TITLE
#365; return error messages for requests that time out.

### DIFF
--- a/static/scripts/dashboard/dashboard.html
+++ b/static/scripts/dashboard/dashboard.html
@@ -1049,13 +1049,13 @@
                     </div>
                   </div>
                 </div>
-                <div class="col-md-10">
+                <div class="col-md-10" ng-if="vm.isLoaded && vm.initialized">
                   &nbsp;
                   <p>
                     Core services to be installed:
                   </p>
                 </div>
-                <div class="col-md-offset-1 col-md-10">
+                <div class="col-md-offset-1 col-md-10" ng-if="vm.isLoaded && vm.initialized">
                   <div class="row">
                     <div class="col-md-offset-2 col-md-10">
                       <div class="row">
@@ -1089,7 +1089,7 @@
                 <div>
                   &nbsp;
                 </div>
-                <div class="col-md-offset-1 col-md-10 text-right">
+                <div class="col-md-offset-1 col-md-10 text-right" ng-if="vm.isLoaded && vm.initialized">
                   <p>
                     &nbsp;
                   </p>

--- a/static/scripts/services/admiralService.js
+++ b/static/scripts/services/admiralService.js
@@ -15,14 +15,25 @@
     admiralService
   ]);
 
+  var timeout = 120000;
+
   function admiralService(ADMIRAL_URL, $http, $rootScope) {
     function handler(promise, callback) {
+      var startTime = Date.now();
       if (callback)
         promise
           .success(function (data) {
             callback(null, data);
           })
           .error(function (data) {
+            if (!data) {
+              var endTime = Date.now();
+              if ((endTime - startTime) >= timeout)
+                return callback('Request timed out', null);
+              else
+                return callback('Request failed', null);
+            }
+
             callback(data, null);
           });
 
@@ -35,7 +46,8 @@
         var promise = $http.get(ADMIRAL_URL + path, {
           headers: {
             Authorization: 'apiToken ' + $rootScope._r.loginToken
-          }
+          },
+          timeout: timeout
         });
         return handler(promise, callback);
       },
@@ -43,7 +55,8 @@
         var promise = $http.put(ADMIRAL_URL + path, body, {
           headers: {
             Authorization: 'apiToken ' + $rootScope._r.loginToken
-          }
+          },
+          timeout: timeout
         });
         return handler(promise, callback);
       },
@@ -51,7 +64,8 @@
         var promise = $http.post(ADMIRAL_URL + path, body, {
           headers: {
             Authorization: 'apiToken ' + $rootScope._r.loginToken
-          }
+          },
+          timeout: timeout
         });
         return handler(promise, callback);
       },
@@ -59,7 +73,8 @@
         var promise = $http.delete(ADMIRAL_URL + path, {
           headers: {
             Authorization: 'apiToken ' + $rootScope._r.loginToken
-          }
+          },
+          timeout: timeout
         });
         return handler(promise, callback);
       }


### PR DESCRIPTION
#365 

Tested by adding `sleep 3m` after the `docker pull` to force the `POST /api/services` calls to time out.