### PR TITLE
Disable masterIntegration when the last systemInt using it is deleted

### DIFF
--- a/api/systemIntegrations/put.js
+++ b/api/systemIntegrations/put.js
@@ -33,7 +33,8 @@ function put(req, res) {
       _postProvider.bind(null, bag),
       _put.bind(null, bag),
       _getUpdatedSystemIntegration.bind(null, bag),
-      _postSystemIntegrationFieldsToVault.bind(null, bag)
+      _postSystemIntegrationFieldsToVault.bind(null, bag),
+      _putMasterIntegration.bind(null, bag)
     ],
     function (err) {
       logger.info(bag.who, 'Completed');
@@ -389,4 +390,26 @@ function __validateKeys(keyValuePair) {
     );
 
   return result;
+}
+
+function _putMasterIntegration(bag, next) {
+  var who = bag.who + '|' + _putMasterIntegration.name;
+  logger.verbose(who, 'Inside');
+
+  var update = {
+    isEnabled: true
+  };
+
+  bag.apiAdapter.putMasterIntegrationById(
+    bag.systemIntegration.masterIntegrationId, update,
+    function (err) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'Failed to put master integration: ' + util.inspect(err))
+        );
+
+      return next();
+    }
+  );
 }

--- a/common/scripts/configs/services.json
+++ b/common/scripts/configs/services.json
@@ -5,7 +5,8 @@
       "type": "generic",
       "services": [
         "marshaller",
-        "ec2"
+        "ec2",
+        "logup"
       ]
     },
     {
@@ -303,8 +304,7 @@
     },
     {
       "name": "logup",
-      "repository": "micro",
-      "isCore": true
+      "repository": "micro"
     },
     {
       "name": "marshaller",


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/407

- When the last systemInt using a masterInt is deleted, disable that masterInt
- Call a put on the masterInt to enable the masterInt when PUT systemInt is called (this handle the case where the services have been deleted from the db, and the user clicks install; all previously existing services managed by the install button will be brought back up)
- Removes logup from core services; it is now booted when amazonKeys is enabled
- Calls PUT /masterIntegration for all masterInts in the addons panel each time the "Install Addons" button is clicked


