### PR TITLE
#416; moves installer prompts.

### DIFF
--- a/admiral.sh
+++ b/admiral.sh
@@ -49,8 +49,8 @@ source "$LIB_DIR/_parseArgs.sh"
 main() {
   __check_logsdir
   __parse_args "$@"
-  __check_dependencies
   __validate_runtime
+  __check_dependencies
   {
     __print_runtime
     source "$SCRIPTS_DIR/$OS_TYPE/installDb.sh"

--- a/api/workflow/initialize.js
+++ b/api/workflow/initialize.js
@@ -9,7 +9,6 @@ var path = require('path');
 var fs = require('fs-extra');
 
 var APIAdapter = require('../../common/APIAdapter.js');
-var envHandler = require('../../common/envHandler.js');
 
 function initialize(req, res) {
   var bag = {
@@ -18,9 +17,7 @@ function initialize(req, res) {
     res: res,
     resBody: {},
     apiAdapter: new APIAdapter(req.headers.authorization.split(' ')[1]),
-    msgInitialized: false,
-    accessKeyEnv: 'ACCESS_KEY',
-    secretKeyEnv: 'SECRET_KEY'
+    msgInitialized: false
   };
 
   bag.who = util.format('workflow|%s', self.name);
@@ -28,8 +25,6 @@ function initialize(req, res) {
 
   async.series([
       _checkInputParams.bind(null, bag),
-      _saveAccessKey.bind(null, bag),
-      _saveSecretKey.bind(null, bag),
       _sendResponse.bind(null, bag),
       _initializeDatabase.bind(null, bag),
       _getSecrets.bind(null, bag),
@@ -77,46 +72,6 @@ function _checkInputParams(bag, next) {
   }
 
   return next();
-}
-
-function _saveAccessKey(bag, next) {
-  if (!bag.reqBody.accessKey) return next();
-  var who = bag.who + '|' + _saveAccessKey.name;
-  logger.verbose(who, 'Inside');
-
-  envHandler.put(bag.accessKeyEnv, bag.reqBody.accessKey,
-    function (err) {
-      if (err)
-        return next(
-          new ActErr(who, ActErr.OperationFailed,
-            'Cannot set env: ' + bag.accessKeyEnv)
-        );
-
-      logger.debug('Set access key');
-
-      return next();
-    }
-  );
-}
-
-function _saveSecretKey(bag, next) {
-  if (!bag.reqBody.secretKey) return next();
-  var who = bag.who + '|' + _saveSecretKey.name;
-  logger.verbose(who, 'Inside');
-
-  envHandler.put(bag.secretKeyEnv, bag.reqBody.secretKey,
-    function (err) {
-      if (err)
-        return next(
-          new ActErr(who, ActErr.OperationFailed,
-            'Cannot set env: ' + bag.secretKeyEnv)
-        );
-
-      logger.debug('Set secret key');
-
-      return next();
-    }
-  );
 }
 
 function _sendResponse(bag, next) {

--- a/common/scripts/lib/_parseArgs.sh
+++ b/common/scripts/lib/_parseArgs.sh
@@ -57,13 +57,20 @@ __validate_runtime() {
     __process_msg "LOGIN_TOKEN available, skipping"
   fi
 
-  ################## check keys  ##################################
-
-  if [ -f "$SSH_PRIVATE_KEY" ] && [ -f $SSH_PUBLIC_KEY ]; then
-    __process_msg "SSH keys already present, skipping"
+  ################## check access key ###############################
+  if [ "$ACCESS_KEY" == "" ]; then
+    __process_msg "ACCESS_KEY is not set"
+    __set_access_key
   else
-    __process_msg "SSH keys not available, generating"
-    __generate_ssh_keys
+    __process_msg "ACCESS_KEY already set, skipping"
+  fi
+
+  ################## check secret key ###############################
+  if [ "$SECRET_KEY" == "" ]; then
+    __process_msg "SECRET_KEY is not set"
+    __set_secret_key
+  else
+    __process_msg "SECRET_KEY already set, skipping"
   fi
 
   ################## check host ip #################################

--- a/static/scripts/dashboard/dashboard.html
+++ b/static/scripts/dashboard/dashboard.html
@@ -35,20 +35,6 @@
                     ng-model="vm.initializeForm.statePassword" ng-disabled="vm.systemSettings.state.isInitialized || vm.initializing"/>
                   </div>
                 </div>
-                <div ng-if="!vm.initialized" class="row">
-                  <span class="col-md-7">Enter your installer access key:</span>
-                  <div class="col-md-5">
-                    <input type="text" class="form-control" name="accessKey"
-                    ng-model="vm.initializeForm.accessKey" ng-disabled="vm.admiralEnv.ACCESS_KEY || vm.initializing"/>
-                  </div>
-                </div>
-                <div ng-if="!vm.initialized" class="row">
-                  <span class="col-md-7">Enter your installer secret key:</span>
-                  <div class="col-md-5">
-                    <input type="text" class="form-control" name="secretKey"
-                    ng-model="vm.initializeForm.secretKey" ng-disabled="vm.admiralEnv.SECRET_KEY || vm.initializing"/>
-                  </div>
-                </div>
                 <div class="row">
                   <table class="table table-condensed table-striped">
                     <thead>

--- a/static/scripts/dashboard/dashboardCtrl.js
+++ b/static/scripts/dashboard/dashboardCtrl.js
@@ -32,9 +32,7 @@
       installing: false,
       initializeForm: {
         msgPassword: '',
-        statePassword: '',
-        accessKey: '',
-        secretKey: ''
+        statePassword: ''
       },
       // map by systemInt name, then masterName
       installForm: {
@@ -437,13 +435,6 @@
           }
 
           $scope.vm.admiralEnv = admiralEnv;
-
-          if (admiralEnv.ACCESS_KEY)
-            $scope.vm.initializeForm.accessKey = admiralEnv.ACCESS_KEY;
-
-          if (admiralEnv.SECRET_KEY)
-            $scope.vm.initializeForm.secretKey = admiralEnv.SECRET_KEY;
-
           return next();
         }
       );


### PR DESCRIPTION
#416 

Removes the installer key from the UI and moves it to the CLI, moves all the prompts requiring user input to before the installations to make it easer to run the installer, and changes the prompt text color to match the access token at the end so that it's easier to tell what requires input.  Tested on a new Digital Ocean installation.  This required moving the SSH key generation so that it would still be after installing ssh, but that doesn't require any user input.

![screenshot from 2017-04-30 10 26 39](https://cloud.githubusercontent.com/assets/5492015/25566657/417fe2ea-2d92-11e7-97f9-eba79428785f.png)
![screenshot from 2017-04-30 09 59 07](https://cloud.githubusercontent.com/assets/5492015/25566656/41797658-2d92-11e7-86b6-5c9a63813b85.png)
