### PR TITLE
#419; adds GET /api/version.

### DIFF
--- a/api/versions/Routes.js
+++ b/api/versions/Routes.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = authRoutes;
+var validateAccount = require('../../common/auth/validateAccount.js');
+
+function authRoutes(app) {
+  app.get('/api/version', validateAccount, require('./get.js'));
+}

--- a/api/versions/get.js
+++ b/api/versions/get.js
@@ -1,0 +1,90 @@
+'use strict';
+
+var self = get;
+module.exports = self;
+
+var async = require('async');
+var _ = require('underscore');
+
+var fs = require('fs');
+var readline = require('readline');
+
+function get(req, res) {
+  var bag = {
+    reqQuery: req.query,
+    resBody: {},
+    versionFile: '/home/shippable/admiral/version.txt'
+  };
+
+  bag.who = util.format('versions|%s', self.name);
+  logger.info(bag.who, 'Starting');
+
+  async.series([
+    _checkInputParams.bind(null, bag),
+    _checkFileExists.bind(null, bag),
+    _get.bind(null, bag)
+  ],
+    function (err) {
+      logger.info(bag.who, 'Completed');
+      if (err)
+        return respondWithError(res, err);
+
+      sendJSONResponse(res, bag.resBody);
+    }
+  );
+}
+
+function _checkFileExists(bag, next) {
+  var who = bag.who + '|' + _checkFileExists.name;
+  logger.verbose(who, 'Inside');
+
+  fs.stat(bag.versionFile,
+    function (err) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'Failed to get ' + bag.versionFile +
+            ' with error: ' + util.inspect(err))
+        );
+
+      return next();
+    }
+  );
+}
+
+function _checkInputParams(bag, next) {
+  var who = bag.who + '|' + _checkInputParams.name;
+  logger.verbose(who, 'Inside');
+
+  return next();
+}
+
+function _get(bag, next) {
+  var who = bag.who + '|' + _get.name;
+  logger.verbose(who, 'Inside');
+
+  var filereader = readline.createInterface({
+    input: fs.createReadStream(bag.versionFile),
+    console: false
+  });
+
+  filereader.on('line',
+    function (envLine) {
+      if (!_.isEmpty(envLine))
+        bag.resBody.version = envLine;
+    }
+  );
+
+  filereader.on('close',
+    function (err) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+          'Failed to read ' + bag.versionFile +
+          ' with error ' + util.inspect(err))
+        );
+
+      return next();
+    }
+  );
+}


### PR DESCRIPTION
#419 

Returns an object with `version`, which is the version in the version.txt file in the admiral container.  I'm not sure how this will work for `master`; the version in this file isn't ever `master`.