### PR TITLE
#439; removes docker pull from boot_service.sh and startFakeApi.sh.

### DIFF
--- a/common/scripts/boot_service.sh
+++ b/common/scripts/boot_service.sh
@@ -32,11 +32,6 @@ __registry_login() {
   eval "$docker_login_cmd"
 }
 
-__pull_image() {
-  __process_msg "Pulling service image: $SERVICE_IMAGE"
-  sudo docker pull $SERVICE_IMAGE
-}
-
 __cleanup_containers() {
   __process_msg "Stopping stale container for the service"
   sudo docker rm -f $SERVICE_NAME || true
@@ -68,7 +63,6 @@ main() {
     __process_marker "Booting service: $SERVICE_NAME"
     __validate_service_configs
     __registry_login
-    __pull_image
     __cleanup_containers
     __cleanup_service
     __run_service

--- a/common/scripts/docker/startFakeAPI.sh
+++ b/common/scripts/docker/startFakeAPI.sh
@@ -50,11 +50,6 @@ __docker_login() {
   eval "$docker_login_cmd"
 }
 
-__pull_image() {
-  __process_msg "Pulling API image: $API_IMAGE"
-  sudo docker pull $API_IMAGE
-}
-
 __run_api() {
   __process_msg "Running api container"
 
@@ -128,7 +123,6 @@ main() {
 
   __validate_api_envs
   __docker_login
-  __pull_image
   __run_api
   __check_api
 


### PR DESCRIPTION
#439 

Removes the `docker pull` commands for services since the images have already been pulled.