### PR TITLE
#460; adds docker pull for public images.

### DIFF
--- a/admiral.sh
+++ b/admiral.sh
@@ -32,6 +32,7 @@ readonly DOCKER_VERSION=1.13
 readonly AWSCLI_VERSION=1.10.63
 readonly API_TIMEOUT=600
 declare -a SERVICE_IMAGES=("api" "www" "micro" "mktg" "nexec")
+declare -a PUBLIC_REGISTRY_IMAGES=("admiral" "postgres" "vault" "rabbitmq" "gitlab" "redis")
 export LC_ALL=C
 
 # Installation default values #############################

--- a/common/scripts/boot_admiral.sh
+++ b/common/scripts/boot_admiral.sh
@@ -37,13 +37,6 @@ __boot_admiral() {
 
   local admiral_image="$PUBLIC_IMAGE_REGISTRY/admiral:$RELEASE"
 
-  local pull_cmd="sudo docker pull $admiral_image"
-
-  __process_msg "Executing: $pull_cmd"
-
-  eval "$pull_cmd"
-  __process_msg "Admiral image successfully pulled"
-
   local boot_cmd="sudo docker run -d \
     $envs \
     $mounts \

--- a/common/scripts/lib/_helpers.sh
+++ b/common/scripts/lib/_helpers.sh
@@ -124,6 +124,12 @@ __pull_images() {
     __process_msg "Pulling $image"
     sudo docker pull $image
   done
+
+  for image in "${PUBLIC_REGISTRY_IMAGES[@]}"; do
+    image="$PUBLIC_IMAGE_REGISTRY/$image:$RELEASE"
+    __process_msg "Pulling $image"
+    sudo docker pull $image
+  done
 }
 
 __print_runtime() {


### PR DESCRIPTION
#460 

Pulls the listed images when running `./admiral install` before any of these images are needed.  This allowed the `docker pull` to be removed from `boot_admiral.sh` because the Admiral image will have already been pulled.