### PR TITLE
#464; moves SSH key generation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@
     - 50003: Shippable admin panel
 
 ### Running the installer
-#### Log into the instance and install `git`
+#### Log into the instance and install `git` and `ssh`
 ```
 $ sudo apt-get update
-$ sudo apt-get install git-core
+$ sudo apt-get install git-core ssh
 ```
 
 #### Upgrade kernel

--- a/common/scripts/lib/_helpers.sh
+++ b/common/scripts/lib/_helpers.sh
@@ -39,14 +39,6 @@ __check_dependencies() {
     apt-get install -y ssh-client
   fi
 
-  ################## Generate SSH keys  ##################################
-  if [ -f "$SSH_PRIVATE_KEY" ] && [ -f $SSH_PUBLIC_KEY ]; then
-    __process_msg "SSH keys already present, skipping"
-  else
-    __process_msg "SSH keys not available, generating"
-    __generate_ssh_keys
-  fi
-
   ################## Install jq  #########################################
   if type jq &> /dev/null && true; then
     __process_msg "'jq' already installed"
@@ -153,9 +145,13 @@ __print_runtime() {
 }
 
 __generate_ssh_keys() {
-  __process_msg "Generating SSH keys"
-  local keygen_exec=$(ssh-keygen -t rsa -P "" -f $SSH_PRIVATE_KEY)
-  __process_msg "SSH keys successfully generated"
+  if [ -f "$SSH_PRIVATE_KEY" ] && [ -f $SSH_PUBLIC_KEY ]; then
+    __process_msg "SSH keys already present, skipping"
+  else
+    __process_msg "SSH keys not available, generating"
+    local keygen_exec=$(ssh-keygen -t rsa -P "" -f $SSH_PRIVATE_KEY)
+    __process_msg "SSH keys successfully generated"
+  fi
 }
 
 __generate_login_token() {

--- a/common/scripts/lib/_parseArgs.sh
+++ b/common/scripts/lib/_parseArgs.sh
@@ -210,6 +210,7 @@ __parse_args() {
       install)
         shift
         __bootstrap_admiral_env
+        __generate_ssh_keys
         __parse_args_install "$@"
         ;;
       status)


### PR DESCRIPTION
#464 

Combines SSH key generation with checking if the keys already exist so it's all in one function and calls this function right after creating the `admiral.env` file (so the `/etc/shippable` folder exists).  I left `ssh` in the dependencies installation just in case we have copied keys but `ssh` isn't installed.