### PR TITLE
Separate POST secrets into two routes

### DIFF
--- a/api/secrets/Routes.js
+++ b/api/secrets/Routes.js
@@ -7,4 +7,6 @@ function secretsRoutes(app) {
   app.get('/api/secrets', validateAccount, require('./get.js'));
   app.get('/api/secrets/logs', validateAccount, require('./getLogs.js'));
   app.post('/api/secrets', validateAccount, require('./post.js'));
+  app.post('/api/secrets/initialize', validateAccount,
+    require('./initialize.js'));
 }

--- a/api/secrets/initialize.js
+++ b/api/secrets/initialize.js
@@ -1,0 +1,378 @@
+'use strict';
+
+var self = post;
+module.exports = self;
+
+var async = require('async');
+var _ = require('underscore');
+var path = require('path');
+var fs = require('fs');
+var readline = require('readline');
+var spawn = require('child_process').spawn;
+
+var envHandler = require('../../common/envHandler.js');
+var configHandler = require('../../common/configHandler.js');
+var APIAdapter = require('../../common/APIAdapter.js');
+
+function post(req, res) {
+  var bag = {
+    reqQuery: req.query,
+    resBody: [],
+    res: res,
+    params: {},
+    apiAdapter: new APIAdapter(req.headers.authorization.split(' ')[1]),
+    skipStatusChange: false,
+    isResponseSent: false,
+    component: 'secrets',
+    tmpScript: '/tmp/secrets.sh',
+    vaultUrlEnv: 'VAULT_URL'
+  };
+
+  bag.who = util.format('secrets|%s', self.name);
+  logger.info(bag.who, 'Starting');
+
+  async.series([
+      _checkInputParams.bind(null, bag),
+      _get.bind(null, bag),
+      _getReleaseVersion.bind(null, bag),
+      _setProcessingFlag.bind(null, bag),
+      _sendResponse.bind(null, bag),
+      _generateInitializeEnvs.bind(null, bag),
+      _generateInitializeScript.bind(null, bag),
+      _writeScriptToFile.bind(null, bag),
+      _initializeVault.bind(null, bag),
+      _getUnsealKeys.bind(null, bag),
+      _getVaultRootToken.bind(null, bag),
+      _post.bind(null, bag),
+      _updateVaultUrl.bind(null, bag)
+    ],
+    function (err) {
+      logger.info(bag.who, 'Completed');
+      if (!bag.skipStatusChange)
+        _setCompleteStatus(bag, err);
+
+      if (err) {
+        // only send a response if we haven't already
+        if (!bag.isResponseSent)
+          respondWithError(bag.res, err);
+        else
+          logger.warn(err);
+      }
+    }
+  );
+}
+
+function _checkInputParams(bag, next) {
+  var who = bag.who + '|' + _checkInputParams.name;
+  logger.verbose(who, 'Inside');
+
+  return next();
+}
+
+function _get(bag, next) {
+  var who = bag.who + '|' + _get.name;
+  logger.verbose(who, 'Inside');
+
+  configHandler.get(bag.component,
+    function (err, secrets) {
+      if (err) {
+        bag.skipStatusChange = true;
+        return next(
+          new ActErr(who, ActErr.DataNotFound,
+            'Failed to get ' + bag.component, err)
+        );
+      }
+
+      if (_.isEmpty(secrets)) {
+        bag.skipStatusChange = true;
+        return next(
+          new ActErr(who, ActErr.DataNotFound,
+            'No configuration in database for ' + bag.component)
+        );
+      }
+
+      bag.config = secrets;
+      return next();
+    }
+  );
+}
+
+function _getReleaseVersion(bag, next) {
+  var who = bag.who + '|' + _getReleaseVersion.name;
+  logger.verbose(who, 'Inside');
+
+  var query = '';
+  bag.apiAdapter.getSystemSettings(query,
+    function (err, systemSettings) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'Failed to get system settings : ' + util.inspect(err))
+        );
+
+      bag.releaseVersion = systemSettings.releaseVersion;
+
+      return next();
+    }
+  );
+}
+
+function _setProcessingFlag(bag, next) {
+  var who = bag.who + '|' + _setProcessingFlag.name;
+  logger.verbose(who, 'Inside');
+
+  var update = {
+    isProcessing: true,
+    isFailed: false
+  };
+
+  configHandler.put(bag.component, update,
+    function (err) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'Failed to update config for ' + bag.component, err)
+        );
+
+      return next();
+    }
+  );
+}
+
+function _sendResponse(bag, next) {
+  var who = bag.who + '|' + _checkInputParams.name;
+  logger.verbose(who, 'Inside');
+
+  // We reply early so the request won't time out while
+  // waiting for the service to start.
+
+  sendJSONResponse(bag.res, bag.resBody, 202);
+  bag.isResponseSent = true;
+  return next();
+}
+
+function _generateInitializeEnvs(bag, next) {
+  var who = bag.who + '|' + _generateInitializeEnvs.name;
+  logger.verbose(who, 'Inside');
+
+  bag.scriptEnvs = {
+    'RUNTIME_DIR': global.config.runtimeDir,
+    'CONFIG_DIR': global.config.configDir,
+    'RELEASE': bag.releaseVersion,
+    'SCRIPTS_DIR': global.config.scriptsDir,
+    'IS_INITIALIZED': bag.config.isInitialized,
+    'IS_INSTALLED': bag.config.isInstalled,
+    'DBUSERNAME': global.config.dbUsername,
+    'DBPASSWORD': global.config.dbPassword,
+    'DBHOST': global.config.dbHost,
+    'DBPORT': global.config.dbPort,
+    'DBNAME': global.config.dbName,
+    'VAULT_HOST': global.config.admiralIP,
+    'VAULT_PORT': bag.config.port
+  };
+
+  return next();
+}
+
+function _generateInitializeScript(bag, next) {
+  var who = bag.who + '|' + _generateInitializeScript.name;
+  logger.verbose(who, 'Inside');
+
+  //attach header
+  var filePath = path.join(global.config.scriptsDir, '/lib/_logger.sh');
+  var headerScript = '';
+  headerScript = headerScript.concat(__applyTemplate(filePath, bag.params));
+
+  var initializeScript = headerScript;
+  filePath = path.join(global.config.scriptsDir, 'docker/installVault.sh');
+  initializeScript = headerScript.concat(__applyTemplate(filePath, bag.params));
+
+  bag.script = initializeScript;
+  return next();
+}
+
+function _writeScriptToFile(bag, next) {
+  var who = bag.who + '|' + _writeScriptToFile.name;
+  logger.debug(who, 'Inside');
+
+  fs.writeFile(bag.tmpScript,
+    bag.script,
+    function (err) {
+      if (err) {
+        var msg = util.format('%s, Failed with err:%s', who, err);
+        return next(
+          new ActErr(
+            who, ActErr.OperationFailed, msg)
+        );
+      }
+      fs.chmodSync(bag.tmpScript, '755');
+      return next();
+    }
+  );
+}
+
+
+function _initializeVault(bag, next) {
+  var who = bag.who + '|' + _initializeVault.name;
+  logger.verbose(who, 'Inside');
+
+  var exec = spawn('/bin/bash',
+    ['-c', bag.tmpScript],
+    {
+      env: bag.scriptEnvs
+    }
+  );
+
+  exec.stdout.on('data',
+    function (data)  {
+      console.log(data.toString());
+    }
+  );
+
+  exec.stderr.on('data',
+    function (data)  {
+      console.log(data.toString());
+    }
+  );
+
+  exec.on('close',
+    function (exitCode)  {
+      if (exitCode > 0)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'Script returned code: ' + exitCode)
+        );
+      return next();
+    }
+  );
+}
+
+function _getUnsealKeys(bag, next) {
+  var who = bag.who + '|' + _getUnsealKeys.name;
+  logger.verbose(who, 'Inside');
+
+  var keyIndex = 1;
+  var unsealKeysFile = path.join(
+    global.config.configDir, bag.component, 'scripts/keys.txt');
+
+  var filereader = readline.createInterface({
+    input: fs.createReadStream(unsealKeysFile),
+    console: false
+  });
+
+  filereader.on('line',
+    function (line) {
+      // this is the format in which unseal keys are stored
+      var keyString = util.format('Unseal Key %s:', keyIndex);
+      if (!_.isEmpty(line) && line.indexOf(keyString) >= 0) {
+        var value = line.split(' ')[3];
+        var keyNameInConfig = 'unsealKey' + keyIndex;
+
+        // set the unseal key in config object
+        bag.config[keyNameInConfig] = value;
+
+        // parse next key
+        keyIndex ++;
+      }
+    }
+  );
+
+  filereader.on('close',
+    function () {
+      return next(null);
+    }
+  );
+}
+
+function _getVaultRootToken(bag, next) {
+  var who = bag.who + '|' + _getVaultRootToken.name;
+  logger.verbose(who, 'Inside');
+
+  envHandler.get('VAULT_TOKEN',
+    function (err, value) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'Failed to get VAULT_TOKEN with error: ' + err)
+        );
+
+      if (_.isEmpty(value))
+        return next(
+          new ActErr(who, ActErr.DataNotFound,
+            'empty VAULT_TOKEN in admiral.env')
+        );
+
+      bag.config.rootToken = value;
+      return next();
+    }
+  );
+}
+
+function _post(bag, next) {
+  var who = bag.who + '|' + _post.name;
+  logger.verbose(who, 'Inside');
+
+  // The keys have been added to bag.config
+  bag.config.isInstalled = true;
+  bag.config.isInitialized = true;
+
+  configHandler.put(bag.component, bag.config,
+    function (err) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'Failed to update config for ' + bag.component, err)
+        );
+
+      return next();
+    }
+  );
+}
+
+function _updateVaultUrl(bag, next) {
+  var who = bag.who + '|' +  _updateVaultUrl.name;
+  logger.verbose(who, 'Inside');
+
+  var vaultUrl = util.format('http://%s:%s',
+    bag.config.address, bag.config.port);
+
+  envHandler.put(bag.vaultUrlEnv, vaultUrl,
+    function (err) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'Cannot set env: ' + bag.vaultUrlEnv + ' err: ' + err)
+        );
+
+      return next();
+    }
+  );
+}
+
+function _setCompleteStatus(bag, err) {
+  var who = bag.who + '|' + _setCompleteStatus.name;
+  logger.verbose(who, 'Inside');
+
+  var update = {
+    isProcessing: false
+  };
+  if (err)
+    update.isFailed = true;
+  else
+    update.isFailed = false;
+
+  configHandler.put(bag.component, update,
+    function (err) {
+      if (err)
+        logger.warn(err);
+    }
+  );
+}
+
+//local function to apply vars to template
+function __applyTemplate(filePath, dataObj) {
+  var fileContent = fs.readFileSync(filePath).toString();
+  var template = _.template(fileContent);
+
+  return template({obj: dataObj});
+}

--- a/api/secrets/post.js
+++ b/api/secrets/post.js
@@ -5,25 +5,17 @@ module.exports = self;
 
 var async = require('async');
 var _ = require('underscore');
-var path = require('path');
-var fs = require('fs');
-var readline = require('readline');
-var spawn = require('child_process').spawn;
 
-var envHandler = require('../../common/envHandler.js');
 var configHandler = require('../../common/configHandler.js');
 var APIAdapter = require('../../common/APIAdapter.js');
 
 function post(req, res) {
   var bag = {
-    reqQuery: req.query,
+    reqBody: req.body,
     resBody: [],
-    params: {},
     apiAdapter: new APIAdapter(req.headers.authorization.split(' ')[1]),
-    skipStatusChange: false,
     component: 'secrets',
-    tmpScript: '/tmp/secrets.sh',
-    vaultUrlEnv: 'VAULT_URL'
+    runInit: false,
   };
 
   bag.who = util.format('secrets|%s', self.name);
@@ -32,27 +24,14 @@ function post(req, res) {
   async.series([
       _checkInputParams.bind(null, bag),
       _get.bind(null, bag),
-      _getReleaseVersion.bind(null, bag),
-      _setProcessingFlag.bind(null, bag),
-      _generateInitializeEnvs.bind(null, bag),
-      _generateInitializeScript.bind(null, bag),
-      _writeScriptToFile.bind(null, bag),
-      _initializeVault.bind(null, bag),
-      _getUnsealKeys.bind(null, bag),
-      _getVaultRootToken.bind(null, bag),
-      _post.bind(null, bag),
-      _updateVaultUrl.bind(null, bag)
+      _post.bind(null, bag)
     ],
     function (err) {
       logger.info(bag.who, 'Completed');
-      if (!bag.skipStatusChange)
-        _setCompleteStatus(bag, err);
-
       if (err)
         return respondWithError(res, err);
 
-      //TODO: remove tmp file
-      sendJSONResponse(res, bag.resBody);
+      sendJSONResponse(res, bag.resBody, 202);
     }
   );
 }
@@ -92,270 +71,27 @@ function _get(bag, next) {
   );
 }
 
-function _getReleaseVersion(bag, next) {
-  var who = bag.who + '|' + _getReleaseVersion.name;
-  logger.verbose(who, 'Inside');
-
-  var query = '';
-  bag.apiAdapter.getSystemSettings(query,
-    function (err, systemSettings) {
-      if (err)
-        return next(
-          new ActErr(who, ActErr.OperationFailed,
-            'Failed to get system settings : ' + util.inspect(err))
-        );
-
-      bag.releaseVersion = systemSettings.releaseVersion;
-
-      return next();
-    }
-  );
-}
-
-function _setProcessingFlag(bag, next) {
-  var who = bag.who + '|' + _setProcessingFlag.name;
-  logger.verbose(who, 'Inside');
-
-  var update = {
-    isProcessing: true,
-    isFailed: false
-  };
-
-  configHandler.put(bag.component, update,
-    function (err) {
-      if (err)
-        return next(
-          new ActErr(who, ActErr.OperationFailed,
-            'Failed to update config for ' + bag.component, err)
-        );
-
-      return next();
-    }
-  );
-}
-
-function _generateInitializeEnvs(bag, next) {
-  var who = bag.who + '|' + _generateInitializeEnvs.name;
-  logger.verbose(who, 'Inside');
-
-  bag.scriptEnvs = {
-    'RUNTIME_DIR': global.config.runtimeDir,
-    'CONFIG_DIR': global.config.configDir,
-    'RELEASE': bag.releaseVersion,
-    'SCRIPTS_DIR': global.config.scriptsDir,
-    'IS_INITIALIZED': bag.config.isInitialized,
-    'IS_INSTALLED': bag.config.isInstalled,
-    'DBUSERNAME': global.config.dbUsername,
-    'DBPASSWORD': global.config.dbPassword,
-    'DBHOST': global.config.dbHost,
-    'DBPORT': global.config.dbPort,
-    'DBNAME': global.config.dbName,
-    'VAULT_HOST': global.config.admiralIP,
-    'VAULT_PORT': bag.config.port
-  };
-
-  return next();
-}
-
-function _generateInitializeScript(bag, next) {
-  var who = bag.who + '|' + _generateInitializeScript.name;
-  logger.verbose(who, 'Inside');
-
-  //attach header
-  var filePath = path.join(global.config.scriptsDir, '/lib/_logger.sh');
-  var headerScript = '';
-  headerScript = headerScript.concat(__applyTemplate(filePath, bag.params));
-
-  var initializeScript = headerScript;
-  filePath = path.join(global.config.scriptsDir, 'docker/installVault.sh');
-  initializeScript = headerScript.concat(__applyTemplate(filePath, bag.params));
-
-  bag.script = initializeScript;
-  return next();
-}
-
-function _writeScriptToFile(bag, next) {
-  var who = bag.who + '|' + _writeScriptToFile.name;
-  logger.debug(who, 'Inside');
-
-  fs.writeFile(bag.tmpScript,
-    bag.script,
-    function (err) {
-      if (err) {
-        var msg = util.format('%s, Failed with err:%s', who, err);
-        return next(
-          new ActErr(
-            who, ActErr.OperationFailed, msg)
-        );
-      }
-      fs.chmodSync(bag.tmpScript, '755');
-      return next();
-    }
-  );
-}
-
-
-function _initializeVault(bag, next) {
-  var who = bag.who + '|' + _initializeVault.name;
-  logger.verbose(who, 'Inside');
-
-  var exec = spawn('/bin/bash',
-    ['-c', bag.tmpScript],
-    {
-      env: bag.scriptEnvs
-    }
-  );
-
-  exec.stdout.on('data',
-    function (data)  {
-      console.log(data.toString());
-    }
-  );
-
-  exec.stderr.on('data',
-    function (data)  {
-      console.log(data.toString());
-    }
-  );
-
-  exec.on('close',
-    function (exitCode)  {
-      if (exitCode > 0)
-        return next(
-          new ActErr(who, ActErr.OperationFailed,
-            'Script returned code: ' + exitCode)
-        );
-      return next();
-    }
-  );
-}
-
-function _getUnsealKeys(bag, next) {
-  var who = bag.who + '|' + _getUnsealKeys.name;
-  logger.verbose(who, 'Inside');
-
-  var keyIndex = 1;
-  var unsealKeysFile = path.join(
-    global.config.configDir, bag.component, 'scripts/keys.txt');
-
-  var filereader = readline.createInterface({
-    input: fs.createReadStream(unsealKeysFile),
-    console: false
-  });
-
-  filereader.on('line',
-    function (line) {
-      // this is the format in which unseal keys are stored
-      var keyString = util.format('Unseal Key %s:', keyIndex);
-      if (!_.isEmpty(line) && line.indexOf(keyString) >= 0) {
-        var value = line.split(' ')[3];
-        var keyNameInConfig = 'unsealKey' + keyIndex;
-
-        // set the unseal key in config object
-        bag.config[keyNameInConfig] = value;
-
-        // parse next key
-        keyIndex ++;
-      }
-    }
-  );
-
-  filereader.on('close',
-    function () {
-      return next(null);
-    }
-  );
-}
-
-function _getVaultRootToken(bag, next) {
-  var who = bag.who + '|' + _getVaultRootToken.name;
-  logger.verbose(who, 'Inside');
-
-  envHandler.get('VAULT_TOKEN',
-    function (err, value) {
-      if (err)
-        return next(
-          new ActErr(who, ActErr.OperationFailed,
-            'Failed to get VAULT_TOKEN with error: ' + err)
-        );
-
-      if (_.isEmpty(value))
-        return next(
-          new ActErr(who, ActErr.DataNotFound,
-            'empty VAULT_TOKEN in admiral.env')
-        );
-
-      bag.config.rootToken = value;
-      return next();
-    }
-  );
-}
-
 function _post(bag, next) {
   var who = bag.who + '|' + _post.name;
   logger.verbose(who, 'Inside');
 
-  // The keys have been added to bag.config
-  bag.config.isInstalled = true;
-  bag.config.isInitialized = true;
+  if (_.has(bag.reqBody, 'address'))
+    bag.config.address = bag.reqBody.address;
+
+  if (_.has(bag.reqBody, 'rootToken'))
+    bag.config.rootToken = bag.reqBody.rootToken;
 
   configHandler.put(bag.component, bag.config,
-    function (err) {
+    function (err, config) {
       if (err)
         return next(
           new ActErr(who, ActErr.OperationFailed,
             'Failed to update config for ' + bag.component, err)
         );
 
-      return next();
-    }
-  );
-}
-
-function _updateVaultUrl(bag, next) {
-  var who = bag.who + '|' +  _updateVaultUrl.name;
-  logger.verbose(who, 'Inside');
-
-  var vaultUrl = util.format('http://%s:%s',
-    bag.config.address, bag.config.port);
-
-  envHandler.put(bag.vaultUrlEnv, vaultUrl,
-    function (err) {
-      if (err)
-        return next(
-          new ActErr(who, ActErr.OperationFailed,
-            'Cannot set env: ' + bag.vaultUrlEnv + ' err: ' + err)
-        );
+      bag.resBody = config;
 
       return next();
     }
   );
-}
-
-function _setCompleteStatus(bag, err) {
-  var who = bag.who + '|' + _setCompleteStatus.name;
-  logger.verbose(who, 'Inside');
-
-  var update = {
-    isProcessing: false
-  };
-  if (err)
-    update.isFailed = true;
-  else
-    update.isFailed = false;
-
-  configHandler.put(bag.component, update,
-    function (err) {
-      if (err)
-        logger.warn(err);
-    }
-  );
-}
-
-//local function to apply vars to template
-function __applyTemplate(filePath, dataObj) {
-  var fileContent = fs.readFileSync(filePath).toString();
-  var template = _.template(fileContent);
-
-  return template({obj: dataObj});
 }

--- a/api/workflow/initialize.js
+++ b/api/workflow/initialize.js
@@ -125,7 +125,7 @@ function _initializeSecrets(bag, next) {
   var who = bag.who + '|' + _initializeSecrets.name;
   logger.verbose(who, 'Inside');
 
-  bag.apiAdapter.postSecrets({},
+  bag.apiAdapter.initializeSecrets({},
     function (err) {
       if (err)
         return next(
@@ -133,7 +133,9 @@ function _initializeSecrets(bag, next) {
             'Failed to initialize secrets provider', err)
         );
 
-      return next();
+      // temporary timeout until this route is retired
+      logger.debug('Waiting 30 seconds for vault to boot');
+      setTimeout(next, 30000);
     }
   );
 }

--- a/common/APIAdapter.js
+++ b/common/APIAdapter.js
@@ -108,6 +108,12 @@ APIAdapter.prototype.postSecrets =
     this.post(url, body, callback);
   };
 
+APIAdapter.prototype.initializeSecrets =
+  function (body, callback) {
+    var url = '/api/secrets/initialize';
+    this.post(url, body, callback);
+  };
+
 // state
 APIAdapter.prototype.getState =
   function (callback) {

--- a/common/express/sendJSONResponse.js
+++ b/common/express/sendJSONResponse.js
@@ -3,6 +3,7 @@ var self = sendJSONResponse;
 module.exports = self;
 global.sendJSONResponse = self;
 
-function sendJSONResponse(res, obj) {
-  return res.status(200).json(obj);
+function sendJSONResponse(res, obj, statusCode) {
+  var responseCode = statusCode || 200;
+  return res.status(responseCode).json(obj);
 }


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/473

Splits POST /api/secrets into two routes - a generic POST route and an initialize route
- The initialize route returns a 202 after secrets is set to processing

