### PR TITLE
#486; adds new node option for RabbitMQ.

### DIFF
--- a/static/scripts/dashboard/dashboard.html
+++ b/static/scripts/dashboard/dashboard.html
@@ -62,6 +62,7 @@
                           <span ng-if="!vm.systemSettings.db.isProcessing && vm.systemSettings.db.isFailed">failed &#x26a0;</span>
                         </td>
                       </tr>
+                      <!-- Vault -->
                       <tr class="active">
                         <td ng-if="vm.initializeForm.secrets.initType === 'admiral'">
                           <b>Secrets:</b>
@@ -72,11 +73,11 @@
                         <td colspan="5">
                           Install Type:
                           <span>
-                            <input type="radio" ng-model="vm.initializeForm.secrets.initType" value="admiral">
+                            <input type="radio" ng-model="vm.initializeForm.secrets.initType" ng-disabled="vm.systemSettings.secrets.isInitialized || vm.initializing" value="admiral">
                             Admiral Node
                           </span>
                           <span>
-                            <input type="radio" ng-model="vm.initializeForm.secrets.initType" value="new">
+                            <input type="radio" ng-model="vm.initializeForm.secrets.initType" ng-disabled="vm.systemSettings.secrets.isInitialized || vm.initializing" value="new">
                             New Node
                           </span>
                           <span>
@@ -102,7 +103,7 @@
                         </td>
                         <td colspan="3">
                           <div>
-                            <input type="text" class="form-control" name="secretsAddress"
+                            <input type="text" class="form-control" name="secretsAddress" ng-disabled="vm.systemSettings.secrets.isInitialized || vm.initializing"
                             ng-model="vm.initializeForm.secrets.address"/>
                           </div>
                         </td>
@@ -117,10 +118,8 @@
                       <tr class="active" ng-if="vm.initializeForm.secrets.initType === 'new'">
                         <td colspan="6">
                           <div class="ss-action"></div>
-                          <div class="ship-console">
-                            <span style="word-break: break-all;">
-                              {{vm.initializeForm.sshCommand}}
-                            </span>
+                          <div class="ship-console" style="word-break: break-all;">
+                            {{vm.initializeForm.sshCommand}}
                           </div>
                         </td>
                       </tr>
@@ -130,23 +129,24 @@
                           Click here once you have run the above command on your node
                         </td>
                         <td>
-                          <button class="btn btn-info pull-right" ng-click="vm.saveSecrets()" ng-disabled="!vm.initializeForm.secrets.confirmCommand">
-                            Save
-                          </button>
                         </td>
                       </tr>
+                      <!-- RabbitMQ -->
                       <tr>
-                        <td rowspan="2">
+                        <td ng-if="vm.initializeForm.msg.initType === 'admiral'" rowspan="2">
+                          <b>Messaging:</b>
+                        </td>
+                        <td ng-if="vm.initializeForm.msg.initType === 'new'" rowspan="6" style="width: 12.5%;">
                           <b>Messaging:</b>
                         </td>
                         <td colspan="5">
                           Install Type:
                           <span>
-                            <input type="radio" ng-model="vm.initializeForm.msg.initType" value="admiral">
+                            <input type="radio" ng-model="vm.initializeForm.msg.initType" ng-disabled="vm.systemSettings.msg.isInitialized || vm.initializing" value="admiral">
                             Admiral Node
                           </span>
                           <span>
-                            <input type="radio" ng-model="vm.initializeForm.msg.initType" value="new" ng-disabled="true">
+                            <input type="radio" ng-model="vm.initializeForm.msg.initType" ng-disabled="vm.systemSettings.msg.isInitialized || vm.initializing" value="new">
                             New Node
                           </span>
                           <span>
@@ -158,7 +158,7 @@
                           <button class="btn btn-sm btn-default" ng-click="vm.showConfigModal('msg')">config</button>
                           <button class="btn btn-sm btn-default" ng-click="vm.showLogModal('msg')">logs</button>
                         </td>
-                        <td class="text-center">
+                        <td style="width: 12.5%;" class="text-center">
                           <span ng-if="vm.systemSettings.msg.isProcessing">initializing...</span>
                           <span ng-if="!vm.systemSettings.msg.isProcessing && !vm.systemSettings.msg.isFailed">
                             {{vm.systemSettings.msg.isInitialized ? 'initialized' : 'not initialized'}}
@@ -179,6 +179,41 @@
                         <td>
                         </td>
                       </tr>
+                      <tr ng-if="vm.initializeForm.msg.initType === 'new'">
+                        <td colspan="3">
+                          <span>IP address for your new RabbitMQ installation:</span>
+                        </td>
+                        <td colspan="3">
+                          <div>
+                            <input type="text" class="form-control" name="msgAddress" ng-disabled="vm.systemSettings.msg.isInitialized || vm.initializing"
+                            ng-model="vm.initializeForm.msg.address"/>
+                          </div>
+                        </td>
+                        <td>
+                        </td>
+                      </tr>
+                      <tr ng-if="vm.initializeForm.msg.initType === 'new'">
+                        <td colspan="7">
+                          Please run this command on your node to authorize SSH access:
+                        </td>
+                      </tr>
+                      <tr ng-if="vm.initializeForm.msg.initType === 'new'">
+                        <td colspan="6">
+                          <div class="ss-action"></div>
+                          <div class="ship-console" style="word-break: break-all;">
+                            {{vm.initializeForm.sshCommand}}
+                          </div>
+                        </td>
+                      </tr>
+                      <tr ng-if="vm.initializeForm.msg.initType === 'new'">
+                        <td colspan="6">
+                          <input type="checkbox" ng-model="vm.initializeForm.msg.confirmCommand"/>
+                          Click here once you have run the above command on your node
+                        </td>
+                        <td>
+                        </td>
+                      </tr>
+                      <!-- GitLab -->
                       <tr class="active">
                         <td rowspan="2">
                           <b>State:</b>
@@ -186,7 +221,7 @@
                         <td colspan="5">
                           Install Type:
                           <span>
-                            <input type="radio" ng-model="vm.initializeForm.state.initType" value="admiral">
+                            <input type="radio" ng-model="vm.initializeForm.state.initType" ng-disabled="vm.systemSettings.state.isInitialized || vm.initializing" value="admiral">
                             Admiral Node
                           </span>
                           <span>
@@ -223,6 +258,7 @@
                         <td>
                         </td>
                       </tr>
+                      <!-- Redis -->
                       <tr>
                         <td>
                           <b>Redis:</b>
@@ -230,7 +266,7 @@
                         <td colspan="5">
                           Install Type:
                           <span>
-                            <input type="radio" ng-model="vm.initializeForm.redis.initType" value="admiral">
+                            <input type="radio" ng-model="vm.initializeForm.redis.initType" ng-disabled="vm.systemSettings.redis.isInitialized || vm.initializing" value="admiral">
                             Admiral Node
                           </span>
                           <span>
@@ -256,7 +292,8 @@
                       </tr>
                       <tr>
                         <td colspan=8 class="text-right">
-                          <button class="btn btn-md btn-primary" type="submit" ng-disabled="vm.initializing" ng-click="vm.initialize()">
+                          <button class="btn btn-md btn-primary" type="submit" ng-click="vm.initialize()"
+                            ng-disabled="vm.initializing || (vm.initializeForm.secrets.initType === 'new' && !vm.initializeForm.secrets.confirmCommand) || (vm.initializeForm.msg.initType === 'new' && !vm.initializeForm.msg.confirmCommand)">
                             <div ng-if="vm.initializing">
                               Initializing...
                             </div>


### PR DESCRIPTION
#486 

Adds the "new node" option for RabbitMQ and disables the radio buttons when initialized or initializing.  This removes the "save" buttons for now because the database needs to be initialized first.  And adds a separate function to update the initialize form from systemSettings to make sure no addresses are lost before they can be saved.  The initialize button does still need to be disabled when any required input is missing, but that can be done in one of the later tasks.

![screenshot from 2017-05-06 16 26 46](https://cloud.githubusercontent.com/assets/5492015/25776667/a517732c-3279-11e7-9c9b-8812cab0f8ec.png)
