### PR TITLE
Add connect to existing instance option for secrets

### DIFF
--- a/api/msg/get.js
+++ b/api/msg/get.js
@@ -23,6 +23,7 @@ function get(req, res) {
       username: 'shippableRoot',
       password: '',
       isSecure: false,
+      isShippableManaged: true,
       isInstalled: false,
       isInitialized: false
     }

--- a/api/redis/get.js
+++ b/api/redis/get.js
@@ -17,6 +17,7 @@ function get(req, res) {
     defaultConfig: {
       address: global.config.admiralIP,
       port: 6379,
+      isShippableManaged: true,
       isInstalled: false,
       isInitialized: false
     }

--- a/api/secrets/get.js
+++ b/api/secrets/get.js
@@ -23,6 +23,7 @@ function get(req, res) {
       unsealKey3: '',
       unsealKey4: '',
       unsealKey5: '',
+      isShippableManaged: true,
       isInstalled: false,
       isInitialized: false
     }

--- a/api/secrets/post.js
+++ b/api/secrets/post.js
@@ -77,6 +77,9 @@ function _post(bag, next) {
   if (_.has(bag.reqBody, 'rootToken'))
     bag.config.rootToken = bag.reqBody.rootToken;
 
+  if (_.has(bag.reqBody, 'isShippableManaged'))
+    bag.config.isShippableManaged = bag.reqBody.isShippableManaged;
+
   configHandler.put(bag.component, bag.config,
     function (err, config) {
       if (err)

--- a/api/state/get.js
+++ b/api/state/get.js
@@ -20,6 +20,7 @@ function get(req, res) {
       sshPort: 2222,
       securePort: 443,
       rootPassword: '',
+      isShippableManaged: true,
       isInstalled: false,
       isInitialized: false
     }

--- a/static/scripts/dashboard/dashboard.html
+++ b/static/scripts/dashboard/dashboard.html
@@ -70,18 +70,21 @@
                         <td rowspan="5" style="width: 12.5%;" ng-if="vm.initializeForm.secrets.initType === 'new'">
                           <b>Secrets:</b>
                         </td>
+                        <td rowspan="3" style="width: 12.5%;" ng-if="vm.initializeForm.secrets.initType === 'existing'">
+                          <b>Secrets:</b>
+                        </td>
                         <td colspan="5">
-                          Install Type:
+                          Install Location:
                           <span>
                             <input type="radio" ng-model="vm.initializeForm.secrets.initType" ng-disabled="vm.systemSettings.secrets.isInitialized || vm.initializing" value="admiral">
-                            Admiral Node
+                            This Node
                           </span>
                           <span>
                             <input type="radio" ng-model="vm.initializeForm.secrets.initType" ng-disabled="vm.systemSettings.secrets.isInitialized || vm.initializing" value="new">
                             New Node
                           </span>
                           <span>
-                            <input type="radio" ng-model="vm.initializeForm.secrets.initType" value="existing" ng-disabled="true">
+                            <input type="radio" ng-model="vm.initializeForm.secrets.initType" value="existing" ng-disabled="vm.systemSettings.secrets.isInitialized || vm.initializing">
                             Existing
                           </span>
                         </td>
@@ -99,7 +102,7 @@
                       </tr>
                       <tr class="active" ng-if="vm.initializeForm.secrets.initType === 'new'">
                         <td colspan="3">
-                          <span>IP address for your new Vault installation:</span>
+                          <span>IP address where you would like Vault installed:</span>
                         </td>
                         <td colspan="3">
                           <div>
@@ -133,6 +136,32 @@
                         <td>
                         </td>
                       </tr>
+                      <tr class="active" ng-if=" vm.initializeForm.secrets.initType === 'existing'">
+                        <td colspan="3">
+                          <span>IP address of your existing Vault installation:</span>
+                        </td>
+                        <td colspan="3">
+                          <div>
+                            <input type="text" class="form-control" name="secretsAddress" ng-disabled="vm.systemSettings.secrets.isInitialized || vm.initializing"
+                            ng-model="vm.initializeForm.secrets.address"/>
+                          </div>
+                        </td>
+                        <td>
+                        </td>
+                      </tr>
+                      <tr class="active" ng-if="vm.initializeForm.secrets.initType === 'existing'">
+                        <td colspan="3">
+                          <span>Root token for your Vault installation:</span>
+                        </td>
+                        <td colspan="3">
+                          <div>
+                            <input type="text" class="form-control" name="secretsAddress" ng-disabled="vm.systemSettings.secrets.isInitialized || vm.initializing"
+                            ng-model="vm.initializeForm.secrets.rootToken"/>
+                          </div>
+                        </td>
+                        <td>
+                        </td>
+                      </tr>
                       <!-- RabbitMQ -->
                       <tr>
                         <td ng-if="vm.initializeForm.msg.initType === 'admiral'" rowspan="2">
@@ -142,10 +171,10 @@
                           <b>Messaging:</b>
                         </td>
                         <td colspan="5">
-                          Install Type:
+                          Install Location:
                           <span>
                             <input type="radio" ng-model="vm.initializeForm.msg.initType" ng-disabled="vm.systemSettings.msg.isInitialized || vm.initializing" value="admiral">
-                            Admiral Node
+                            This Node
                           </span>
                           <span>
                             <input type="radio" ng-model="vm.initializeForm.msg.initType" ng-disabled="vm.systemSettings.msg.isInitialized || vm.initializing" value="new">
@@ -224,10 +253,10 @@
                           <b>State:</b>
                         </td>
                         <td colspan="5">
-                          Install Type:
+                          Install Location:
                           <span>
                             <input type="radio" ng-model="vm.initializeForm.state.initType" ng-disabled="vm.systemSettings.state.isInitialized || vm.initializing" value="admiral">
-                            Admiral Node
+                            This Node
                           </span>
                           <span>
                             <input type="radio" ng-model="vm.initializeForm.state.initType" ng-disabled="vm.systemSettings.state.isInitialized || vm.initializing" value="new">
@@ -308,10 +337,10 @@
                           <b>Redis:</b>
                         </td>
                         <td colspan="5">
-                          Install Type:
+                          Install Location:
                           <span>
                             <input type="radio" ng-model="vm.initializeForm.redis.initType" ng-disabled="vm.systemSettings.redis.isInitialized || vm.initializing" value="admiral">
-                            Admiral Node
+                            This Node
                           </span>
                           <span>
                             <input type="radio" ng-model="vm.initializeForm.redis.initType" value="new" ng-disabled="vm.systemSettings.redis.isInitialized || vm.initializing">

--- a/static/scripts/dashboard/dashboardCtrl.js
+++ b/static/scripts/dashboard/dashboardCtrl.js
@@ -39,6 +39,7 @@
           //install type can be admiral (same node as admiral), new, or existing
           initType: 'admiral',
           address: '',
+          rootToken: '',
           confirmCommand: false
         },
         msg: {
@@ -475,8 +476,12 @@
             }
           );
 
-          if (!obj.address || obj.address === $scope.vm.admiralEnv.ADMIRAL_IP)
+          if (!_.has($scope.vm.systemSettings[service], 'isShippableManaged') ||
+            !obj.address ||
+            obj.address === $scope.vm.admiralEnv.ADMIRAL_IP)
             $scope.vm.initializeForm[service].initType = 'admiral';
+          else if (!$scope.vm.systemSettings[service].isShippableManaged)
+            $scope.vm.initializeForm[service].initType = 'existing';
           else
             $scope.vm.initializeForm[service].initType = 'new';
 
@@ -983,15 +988,26 @@
     }
 
     function postServicesAndInitSecrets() {
-      var secretsUpdate = {};
+      var secretsUpdate = {
+        address: $scope.vm.admiralEnv.ADMIRAL_IP,
+        isShippableManaged: true
+      };
       var msgUpdate = {
         password: $scope.vm.initializeForm.msg.password,
-        uiPassword: $scope.vm.initializeForm.msg.password
+        uiPassword: $scope.vm.initializeForm.msg.password,
+        address: $scope.vm.admiralEnv.ADMIRAL_IP,
+        isShippableManaged: true
       };
       var stateUpdate = {
-        rootPassword: $scope.vm.initializeForm.state.rootPassword
+        rootPassword: $scope.vm.initializeForm.state.rootPassword,
+        address: $scope.vm.admiralEnv.ADMIRAL_IP,
+        sshPort: 2222,
+        isShippableManaged: true
       };
-      var redisUpdate = {};
+      var redisUpdate = {
+        address: $scope.vm.admiralEnv.ADMIRAL_IP,
+        isShippableManaged: true
+      };
 
       if ($scope.vm.initializeForm.secrets.initType === 'new')
         secretsUpdate.address = $scope.vm.initializeForm.secrets.address;
@@ -1006,6 +1022,12 @@
 
       if ($scope.vm.initializeForm.redis.initType === 'new')
         redisUpdate.address = $scope.vm.initializeForm.redis.address;
+
+      if ($scope.vm.initializeForm.secrets.initType === 'existing') {
+        secretsUpdate.address = $scope.vm.initializeForm.secrets.address;
+        secretsUpdate.rootToken = $scope.vm.initializeForm.secrets.rootToken;
+        secretsUpdate.isShippableManaged = false;
+      }
 
       async.series([
           // get secrets, msg, state, redis


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/512

- Adds connect to existing option for secrets
- Adds isShippableManaged, defaulted to true, to the core services GET routes
- isShippableManaged can be set for secrets on POST