### PR TITLE
#647; updates migrations to include latest changes in Base.

### DIFF
--- a/common/scripts/configs/system_codes.sql
+++ b/common/scripts/configs/system_codes.sql
@@ -126,6 +126,11 @@ do $$
       values (1021, 'cliConfig', 'resource', '54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2016-06-01', '2016-06-01');
     end if;
 
+    if not exists (select 1 from "systemCodes" where code = 1022) then
+      insert into "systemCodes" ("code", "name", "group", "createdBy", "updatedBy", "createdAt", "updatedAt")
+      values (1022, 'state', 'resource', '54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2016-06-01', '2016-06-01');
+    end if;
+
     if not exists (select 1 from "systemCodes" where code = 2000) then
       insert into "systemCodes" ("code", "name", "group", "createdBy", "updatedBy", "createdAt", "updatedAt")
       values (2000, 'manifest', 'resource', '54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2016-06-01', '2016-06-01');
@@ -500,6 +505,16 @@ do $$
     if not exists (select 1 from "systemCodes" where code = 400) then
       insert into "systemCodes" ("code", "name", "group", "createdBy", "updatedBy", "createdAt", "updatedAt")
       values (400, 'project', 'viewObjectType', '54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2016-06-01', '2016-06-01');
+    end if;
+
+    if not exists (select 1 from "systemCodes" where code = 401) then
+      insert into "systemCodes" ("code", "name", "group", "createdBy", "updatedBy", "createdAt", "updatedAt")
+      values (401, 'flag', 'viewObjectType', '54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2016-06-01', '2016-06-01');
+    end if;
+
+    if not exists (select 1 from "systemCodes" where code = 402) then
+      insert into "systemCodes" ("code", "name", "group", "createdBy", "updatedBy", "createdAt", "updatedAt")
+      values (402, 'job', 'viewObjectType', '54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2016-06-01', '2016-06-01');
     end if;
 
     if not exists (select 1 from "systemCodes" where code = 500) then

--- a/migrations/migrations.sql
+++ b/migrations/migrations.sql
@@ -1108,6 +1108,11 @@ do $$
     );
 
     -- set buildJobs routeRoles
+    perform set_route_role(
+      routePattern := '/buildJobs/:buildJobId/artifactUrl',
+      httpVerb := 'GET',
+      roleCode := 6110
+    );
 
     perform set_route_role(
       routePattern := '/buildJobs',
@@ -1870,6 +1875,12 @@ do $$
       routePattern := '/jobs/:jobId/artifactUrl',
       httpVerb := 'GET',
       roleCode := 6020
+    );
+
+    perform set_route_role(
+      routePattern := '/jobs/:jobId/artifactUrl',
+      httpVerb := 'GET',
+      roleCode := 6040
     );
 
     perform set_route_role(
@@ -3971,9 +3982,9 @@ do $$
       alter table "systemNodes" add column "execImage" varchar(80);
     end if;
 
-    -- Add earlyAdopterMinionCount to subscriptions
-    if not exists (select 1 from information_schema.columns where table_name = 'subscriptions' and column_name = 'earlyAdopterMinionCount') then
-      alter table "subscriptions" add column "earlyAdopterMinionCount" INTEGER;
+    -- Drop earlyAdopterMinionCount from subscriptions
+    if exists (select 1 from information_schema.columns where table_name = 'subscriptions' and column_name = 'earlyAdopterMinionCount') then
+      alter table "subscriptions" drop column "earlyAdopterMinionCount";
     end if;
 
     -- Add minionInstanceSize to subscriptions


### PR DESCRIPTION
#647 

Adds `state`, `flag`, and `job` systemCodes, routeRoles for `/buildJobs/:buildJobId/artifactUrl` and `/jobs/:jobId/artifactUrl`, and drops the `earlyAdopterMinionCount` column to match Base.