### PR TITLE
Show/hide auth input boxes when auth provider is clicked

### DIFF
--- a/static/scripts/dashboard/dashboard.html
+++ b/static/scripts/dashboard/dashboard.html
@@ -500,11 +500,11 @@
                         <td colspan="5" style="width: 45%">
                           Worker Install Location:
                           <span>
-                            <input type="radio" ng-model="vm.initializeForm.workers.initType" ng-disabled="vm.initializing" value="admiral">
+                            <input type="radio" ng-model="vm.initializeForm.workers.initType" ng-disabled="((vm.initializeForm.workers.workers[0].isInitialized || vm.initializeForm.workers.workers[0].isFailed) && vm.initializeForm.workers.workers[0].address !== vm.admiralEnv.ADMIRAL_IP) || vm.initializing" value="admiral">
                             This Node
                           </span>
                           <span>
-                            <input type="radio" ng-model="vm.initializeForm.workers.initType" ng-disabled="vm.initializing" value="new">
+                            <input type="radio" ng-model="vm.initializeForm.workers.initType" ng-disabled="((vm.initializeForm.workers.workers[0].isInitialized || vm.initializeForm.workers.workers[0].isFailed) && vm.initializeForm.workers.workers[0].address !== vm.admiralEnv.ADMIRAL_IP) || vm.initializing" value="new">
                             New Node(s)
                           </span>
                         </td>
@@ -729,7 +729,7 @@
           <div class="panel-heading">
             <h3 class="panel-title">
               <a data-toggle="collapse" href="#installpanel">
-                {{(vm.initialized && vm.systemSettings.releaseVersion !== vm.admiralEnv.RELEASE) ? '3.' : '2.'}} Install Services
+                {{(vm.initialized && vm.systemSettings.releaseVersion !== vm.admiralEnv.RELEASE) ? '3.' : '2.'}} Configure & Install Services
               </a>
             </h3>
           </div>
@@ -744,13 +744,18 @@
               <div ng-if="vm.isLoaded && vm.initialized">
                 <div class="col-md-10">
                   &nbsp;
-                  <p>
-                    Configure your auth provider(s).
-                  </p>
+                  <h4 class="panel-title">
+                    Authorization Providers
+                  </h4>
                 </div>
                 <div class="col-md-offset-1 col-md-10">
+                  <div class="row has-error" ng-if="!vm.installForm.auth.bitbucketKeys.isEnabled && !vm.installForm.auth.bitbucketServerKeys.isEnabled && !vm.installForm.auth.githubKeys.isEnabled && !vm.installForm.auth.githubEnterpriseKeys.isEnabled && !vm.installForm.auth.gitlabKeys.isEnabled">
+                    <span class="help-block">
+                      You must configure at least one authorization provider.
+                    </span>
+                  </div>
                   <div class="row">
-                    <div class="col-md-2">
+                    <div class="col-md-10">
                       <div class="checkbox">
                         <label>
                           <input type="checkbox" ng-model="vm.installForm.auth.bitbucketKeys.isEnabled">
@@ -758,8 +763,9 @@
                         </label>
                       </div>
                     </div>
-                    <div class="col-md-10">
-                      <div>&nbsp;</div>
+                  </div>
+                  <div class="row" ng-if="vm.installForm.auth.bitbucketKeys.isEnabled">
+                    <div class="col-md-offset-1 col-md-10">
                       <div class="row">
                         <div class="col-md-3">
                           Client ID
@@ -801,7 +807,7 @@
                 </div>
                 <div class="col-md-offset-1 col-md-10">
                   <div class="row">
-                    <div class="col-md-2">
+                    <div class="col-md-10">
                       <div class="checkbox">
                         <label>
                           <input type="checkbox" ng-model="vm.installForm.auth.bitbucketServerKeys.isEnabled">
@@ -809,8 +815,9 @@
                         </label>
                       </div>
                     </div>
-                    <div class="col-md-10">
-                      <div>&nbsp;</div>
+                  </div>
+                  <div class="row" ng-if="vm.installForm.auth.bitbucketServerKeys.isEnabled">
+                    <div class="col-md-offset-1 col-md-10">
                       <div class="row">
                         <div class="col-md-3">
                           Client ID
@@ -852,7 +859,7 @@
                 </div>
                 <div class="col-md-offset-1 col-md-10">
                   <div class="row">
-                    <div class="col-md-2">
+                    <div class="col-md-10">
                       <div class="checkbox">
                         <label>
                           <input type="checkbox" ng-model="vm.installForm.auth.githubKeys.isEnabled">
@@ -860,8 +867,9 @@
                         </label>
                       </div>
                     </div>
-                    <div class="col-md-10">
-                      <div>&nbsp;</div>
+                  </div>
+                  <div class="row" ng-if="vm.installForm.auth.githubKeys.isEnabled">
+                    <div class="col-md-offset-1 col-md-10">
                       <div class="row">
                         <div class="col-md-3">
                           Client ID
@@ -903,7 +911,7 @@
                 </div>
                 <div class="col-md-offset-1 col-md-10">
                   <div class="row">
-                    <div class="col-md-2">
+                    <div class="col-md-10">
                       <div class="checkbox">
                         <label>
                           <input type="checkbox" ng-model="vm.installForm.auth.githubEnterpriseKeys.isEnabled">
@@ -911,8 +919,9 @@
                         </label>
                       </div>
                     </div>
-                    <div class="col-md-10">
-                      <div>&nbsp;</div>
+                  </div>
+                  <div class="row" ng-if="vm.installForm.auth.githubEnterpriseKeys.isEnabled">
+                    <div class="col-md-offset-1 col-md-10">
                       <div class="row">
                         <div class="col-md-3">
                           Client ID
@@ -954,7 +963,7 @@
                 </div>
                 <div class="col-md-offset-1 col-md-10">
                   <div class="row">
-                    <div class="col-md-2">
+                    <div class="col-md-10">
                       <div class="checkbox">
                         <label>
                           <input type="checkbox" ng-model="vm.installForm.auth.gitlabKeys.isEnabled">
@@ -962,8 +971,9 @@
                         </label>
                       </div>
                     </div>
-                    <div class="col-md-10">
-                      <div>&nbsp;</div>
+                  </div>
+                  <div class="row" ng-if="vm.installForm.auth.gitlabKeys.isEnabled">
+                    <div class="col-md-offset-1 col-md-10">
                       <div class="row">
                         <div class="col-md-3">
                           Application ID


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/649

- Shows/hides the auth input boxes
- Also disables the swarm install location radio buttons when a swarm worker has isInitialized and isFailed set as true