### PR TITLE
#602; fixes existing provider ID.

### DIFF
--- a/baseMigrations/createOrUpdateSystemIntegration.js
+++ b/baseMigrations/createOrUpdateSystemIntegration.js
@@ -146,7 +146,7 @@ function _getExistingProvider(bag, next) {
         );
 
       if (!_.isEmpty(providers.rows) && !_.isEmpty(providers.rows[0]))
-        bag.providerId = providers.rows[0];
+        bag.providerId = providers.rows[0].id;
 
       return next();
     }


### PR DESCRIPTION
#602 

New providers have the ID set, but existing providers were setting the ID to the whole object in the systemIntegration.