### PR TITLE
#761; removes warning on empty access and secret keys.

### DIFF
--- a/static/scripts/dashboard/dashboard.html
+++ b/static/scripts/dashboard/dashboard.html
@@ -39,8 +39,8 @@
                         <td colspan="3">
                         </td>
                         <td>
-                          <div ng-class="vm.initializeForm.installerAccessKey.length ? '' : 'has-error'">
-                            <input type="text" class="form-control input-sm" name="installerAccessKey" placeholder="Access Key" ng-disabled="vm.initializing"
+                          <div>
+                            <input type="text" class="form-control input-sm" name="installerAccessKey" placeholder="Access Key (Optional)" ng-disabled="vm.initializing"
                             ng-model="vm.initializeForm.installerAccessKey"/>
                           </div>
                         </td>
@@ -54,8 +54,8 @@
                         <td colspan="3">
                         </td>
                         <td>
-                          <div ng-class="vm.initializeForm.installerSecretKey.length ? '' : 'has-error'">
-                            <input type="text" class="form-control input-sm" name="installerSecretKey" placeholder="Secret Key" ng-disabled="vm.initializing"
+                          <div>
+                            <input type="text" class="form-control input-sm" name="installerSecretKey" placeholder="Secret Key (Optional)" ng-disabled="vm.initializing"
                             ng-model="vm.initializeForm.installerSecretKey"/>
                           </div>
                         </td>


### PR DESCRIPTION
#761 

Removes the red outline when the boxes are empty and adds "(Optional)" to the placeholders.

![screenshot from 2017-06-02 17 03 31](https://cloud.githubusercontent.com/assets/5492015/26748752/82e91278-47b5-11e7-801b-686022ec558e.png)
