### PR TITLE
#768; hides mktg in Admiral UI.

### DIFF
--- a/static/scripts/dashboard/dashboard.html
+++ b/static/scripts/dashboard/dashboard.html
@@ -1589,7 +1589,7 @@
                         </div>
                       </div>
                       <!-- mktg -->
-                      <div class="col-md-offset-1 col-md-11">
+                      <div class="col-md-offset-1 col-md-11" ng-if="!vm.admiralEnv.IS_SERVER">
                         <div>&nbsp;</div>
                         <div class="row">
                           <div class="col-md-12">
@@ -1597,7 +1597,7 @@
                           </div>
                         </div>
                       </div>
-                      <div class="col-md-offset-2 col-md-10">
+                      <div class="col-md-offset-2 col-md-10" ng-if="!vm.admiralEnv.IS_SERVER">
                         <div class="row">
                           <div class="col-md-4">
                             URL
@@ -2009,7 +2009,7 @@
                         <thead>
                         </thead>
                         <tbody>
-                          <tr ng-repeat="service in vm.allServices" ng-if="service.isEnabled">
+                          <tr ng-repeat="service in vm.allServices" ng-if="service.isEnabled && (service.serviceName !== 'mktg' || !vm.admiralEnv.IS_SERVER)">
                             <td>
                               <b>{{service.serviceName}}</b>
                             </td>


### PR DESCRIPTION
#768 

Hides the marketing URL in the install panel and `mktg` in the services list if `IS_SERVER` is true.  The URL is still saved and the service is started, or www wouldn't work correctly.