### PR TITLE
corrects callbackUrls of scms in admiral UI

### DIFF
--- a/static/scripts/dashboard/dashboardCtrl.js
+++ b/static/scripts/dashboard/dashboardCtrl.js
@@ -25,6 +25,13 @@
 
     $scope._r.showCrumb = false;
     $scope.dashboardCtrlPromise = dashboardCtrlDefer.promise;
+    var providerAuthNames = {
+      bitbucketKeys: 'bitbucket',
+      bitbucketServerKeys: 'bitbucketServer',
+      githubKeys: 'github',
+      githubEnterpriseKeys: 'ghe',
+      gitlabKeys: 'gitlab'
+    };
 
     $scope.vm = {
       isLoaded: false,
@@ -848,22 +855,13 @@
                   systemIntegration.data
                 );
                 $scope.vm.installForm[sysIntName][masterName].isEnabled = true;
+
                 if (sysIntName === 'auth') {
-                  if (masterName === 'bitbucketKeys') {
+                  var providerAuthName = providerAuthNames[masterName];
+                  if (!_.isEmpty(providerAuthName)) {
                     $scope.vm.installForm[sysIntName][masterName].callbackUrl =
-                      systemIntegration.data.wwwUrl + '/auth/bitbucket/' + systemIntegration.id + '/identify';
-                  } else if (masterName === 'bitbucketServerKeys') {
-                    $scope.vm.installForm[sysIntName][masterName].callbackUrl =
-                      systemIntegration.data.wwwUrl + '/auth/bitbucketServer/' + systemIntegration.id + '/identify';
-                  } else if (masterName === 'githubKeys') {
-                    $scope.vm.installForm[sysIntName][masterName].callbackUrl =
-                      systemIntegration.data.wwwUrl + '/auth/github/' + systemIntegration.id + '/identify';
-                  } else if (masterName === 'githubEnterpriseKeys') {
-                    $scope.vm.installForm[sysIntName][masterName].callbackUrl =
-                      systemIntegration.data.wwwUrl + '/auth/ghe/' + systemIntegration.id + '/identify';
-                  } else if (masterName === 'gitlabKeys') {
-                    $scope.vm.installForm[sysIntName][masterName].callbackUrl =
-                      systemIntegration.data.wwwUrl + '/auth/gitlab/' + systemIntegration.id + '/identify';
+                      systemIntegration.data.wwwUrl + '/auth/' + providerAuthName +
+                      '/' + systemIntegration.id + '/identify';
                   }
                 }
               }
@@ -2228,21 +2226,11 @@
               if (err)
                 return done(err);
               if (bag.systemIntegrationId) {
-                if (bag.masterName === 'bitbucketKeys') {
+                var providerAuthName = providerAuthNames[bag.masterName];
+                if (!_.isEmpty(providerAuthName)) {
                   $scope.vm.installForm[bag.name][bag.masterName].callbackUrl =
-                    bag.data.wwwUrl + '/auth/bitbucket/' + bag.systemIntegrationId + '/identify';
-                } else if (bag.masterName === 'bitbucketServerKeys') {
-                  $scope.vm.installForm[bag.name][bag.masterName].callbackUrl =
-                    bag.data.wwwUrl + '/auth/bitbucketServer/' + bag.systemIntegrationId + '/identify';
-                } else if (bag.masterName === 'githubKeys') {
-                  $scope.vm.installForm[bag.name][bag.masterName].callbackUrl =
-                    bag.data.wwwUrl + '/auth/github/' + bag.systemIntegrationId + '/identify';
-                } else if (bag.masterName === 'githubEnterpriseKeys') {
-                  $scope.vm.installForm[bag.name][bag.masterName].callbackUrl =
-                    bag.data.wwwUrl + '/auth/ghe/' + bag.systemIntegrationId + '/identify';
-                } else if (bag.masterName === 'gitlabKeys') {
-                  $scope.vm.installForm[bag.name][bag.masterName].callbackUrl =
-                    bag.data.wwwUrl + '/auth/gitlab/' + bag.systemIntegrationId + '/identify';
+                    bag.data.wwwUrl + '/auth/' + providerAuthName +
+                    '/' + bag.systemIntegrationId + '/identify';
                 }
               }
               return done();

--- a/static/scripts/dashboard/dashboardCtrl.js
+++ b/static/scripts/dashboard/dashboardCtrl.js
@@ -848,9 +848,24 @@
                   systemIntegration.data
                 );
                 $scope.vm.installForm[sysIntName][masterName].isEnabled = true;
-                if (sysIntName === 'auth')
-                  $scope.vm.installForm[sysIntName][masterName].callbackUrl =
-                    systemIntegration.data.wwwUrl + '/' + sysIntName +'/' + systemIntegration.id + '/identify';
+                if (sysIntName === 'auth') {
+                  if (masterName === 'bitbucketKeys') {
+                    $scope.vm.installForm[sysIntName][masterName].callbackUrl =
+                      systemIntegration.data.wwwUrl + '/auth/bitbucket/' + systemIntegration.id + '/identify';
+                  } else if (masterName === 'bitbucketServerKeys') {
+                    $scope.vm.installForm[sysIntName][masterName].callbackUrl =
+                      systemIntegration.data.wwwUrl + '/auth/bitbucketServer/' + systemIntegration.id + '/identify';
+                  } else if (masterName === 'githubKeys') {
+                    $scope.vm.installForm[sysIntName][masterName].callbackUrl =
+                      systemIntegration.data.wwwUrl + '/auth/github/' + systemIntegration.id + '/identify';
+                  } else if (masterName === 'githubEnterpriseKeys') {
+                    $scope.vm.installForm[sysIntName][masterName].callbackUrl =
+                      systemIntegration.data.wwwUrl + '/auth/ghe/' + systemIntegration.id + '/identify';
+                  } else if (masterName === 'gitlabKeys') {
+                    $scope.vm.installForm[sysIntName][masterName].callbackUrl =
+                      systemIntegration.data.wwwUrl + '/auth/gitlab/' + systemIntegration.id + '/identify';
+                  }
+                }
               }
             }
           );
@@ -2212,9 +2227,24 @@
             function (err) {
               if (err)
                 return done(err);
-              if (bag.systemIntegrationId)
-                $scope.vm.installForm[bag.name][bag.masterName].callbackUrl =
-                  bag.data.wwwUrl + '/' + bag.name +'/' + bag.systemIntegrationId + '/identify';
+              if (bag.systemIntegrationId) {
+                if (bag.masterName === 'bitbucketKeys') {
+                  $scope.vm.installForm[bag.name][bag.masterName].callbackUrl =
+                    bag.data.wwwUrl + '/auth/bitbucket/' + bag.systemIntegrationId + '/identify';
+                } else if (bag.masterName === 'bitbucketServerKeys') {
+                  $scope.vm.installForm[bag.name][bag.masterName].callbackUrl =
+                    bag.data.wwwUrl + '/auth/bitbucketServer/' + bag.systemIntegrationId + '/identify';
+                } else if (bag.masterName === 'githubKeys') {
+                  $scope.vm.installForm[bag.name][bag.masterName].callbackUrl =
+                    bag.data.wwwUrl + '/auth/github/' + bag.systemIntegrationId + '/identify';
+                } else if (bag.masterName === 'githubEnterpriseKeys') {
+                  $scope.vm.installForm[bag.name][bag.masterName].callbackUrl =
+                    bag.data.wwwUrl + '/auth/ghe/' + bag.systemIntegrationId + '/identify';
+                } else if (bag.masterName === 'gitlabKeys') {
+                  $scope.vm.installForm[bag.name][bag.masterName].callbackUrl =
+                    bag.data.wwwUrl + '/auth/gitlab/' + bag.systemIntegrationId + '/identify';
+                }
+              }
               return done();
 
             }


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/787

Github: http://localhost:50001/auth/github/594a15740d078343026bdfa5/identify

bitbucket: http://localhost:50001/auth/bitbucket/594a15740d078343026bdfa4/identify

bitbucketServer: http://localhost:50001/auth/bitbucketServer/594a15c9eaf1d14d0223f5b1/identify

ghe: http://localhost:50001/auth/ghe/594a15c9eaf1d14d0223f5b2/identify

gitlab: http://localhost:50001/auth/gitlab/594a15c9eaf1d14d0223f5b3/identify

**NOTE:** Since now auth systemInts use generic masterIntegrations so masterIntName for them were not exactly the name required for constructing the url they are now like githubKeys for github and bitbucketKeys for bitbucket and all so this required some if/else to set the correct name.