### PR TITLE
use genexec for rSync

### DIFF
--- a/api/systemCodes/Routes.js
+++ b/api/systemCodes/Routes.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = systemCodesRoutes;
+var validateAccount = require('../../common/auth/validateAccount.js');
+
+function systemCodesRoutes(app) {
+  app.get('/api/systemCodes', validateAccount, require('./get.js'));
+}

--- a/api/systemCodes/get.js
+++ b/api/systemCodes/get.js
@@ -1,0 +1,66 @@
+'use strict';
+
+var self = get;
+module.exports = self;
+
+var async = require('async');
+var _ = require('underscore');
+
+function get(req, res) {
+  var bag = {
+    reqQuery: req.query,
+    resBody: {}
+  };
+
+  bag.who = util.format('systemCodes|%s', self.name);
+  logger.info(bag.who, 'Starting');
+
+  async.series([
+      _checkInputParams.bind(null, bag),
+      _get.bind(null, bag)
+    ],
+    function (err) {
+      logger.info(bag.who, 'Completed');
+      if (err)
+        return respondWithError(res, err);
+
+      sendJSONResponse(res, bag.resBody);
+    }
+  );
+}
+
+function _checkInputParams(bag, next) {
+  var who = bag.who + '|' + _checkInputParams.name;
+  logger.verbose(who, 'Inside');
+
+  return next();
+}
+
+function _get(bag, next) {
+  var who = bag.who + '|' + _get.name;
+  logger.verbose(who, 'Inside');
+
+  global.config.client.query('SELECT * from "systemCodes"',
+    function (err, systemCodes) {
+      if (err) {
+        if (err.code === '42P01') {
+          logger.debug('systemCodes table not created. Please initialize.');
+          return next();
+        }
+        return next(
+          new ActErr(who, ActErr.DBOperationFailed,
+            'Failed to get systemCodes with error: ' + util.inspect(err))
+        );
+      }
+
+      if (_.isEmpty(systemCodes.rows))
+        return next(
+          new ActErr(who, ActErr.DataNotFound, 'System codes not found')
+        );
+
+      bag.resBody = systemCodes.rows;
+
+      return next();
+    }
+  );
+}

--- a/common/APIAdapter.js
+++ b/common/APIAdapter.js
@@ -215,6 +215,13 @@ APIAdapter.prototype.getSystemSettings =
     this.get(url, callback);
   };
 
+// systemCodes
+APIAdapter.prototype.getSystemCodes =
+  function (query, callback) {
+    var url = '/api/systemCodes?' + query;
+    this.get(url, callback);
+  };
+
 /*****************************************/
 /*              HTTP METHODS             */
 /*****************************************/

--- a/common/scripts/lib/_helpers.sh
+++ b/common/scripts/lib/_helpers.sh
@@ -142,6 +142,12 @@ __pull_images() {
     sudo docker pull $image
   done
 
+  __process_msg "Registry: shipimg"
+  
+  image="shipimg/genexec:$RELEASE"
+  __process_msg "Pulling $image"
+  sudo docker pull $image
+
   __process_msg "Registry: $PRIVATE_IMAGE_REGISTRY"
   __registry_login
 


### PR DESCRIPTION
#931

hardcoding `shipimg` registry. hopefully we can move it to drydock to help with the admiral flow.

also had to make a new api route to get systemCodes so rather than hard code the new 'service' node type code, which genexec needs.

when services are started, the microConfig file has a list of names that belong to genexec (so far just rSync).  It will use different options on the docker run command for genexec images.

testing by running locally and runnign some rSync jobs