### PR TITLE
Updates files to point genexec image to drydock repo instead of shipimg

### DIFF
--- a/api/services/microConfig.js
+++ b/api/services/microConfig.js
@@ -16,6 +16,7 @@ function microConfig(params, callback) {
     config: params.config,
     name: params.name,
     registry: params.registry,
+    publicRegistry: params.publicRegistry,
     envs: '',
     mounts: '',
     runCommand: '',
@@ -177,7 +178,7 @@ function _generateImage(bag, next) {
 
   if (bag.component === 'genExec')
     bag.config.image = util.format('%s/genexec:%s',
-      'drydock', bag.releaseVersion);
+      bag.publicRegistry, bag.releaseVersion);
   else
     bag.config.image = util.format('%s/micro:%s',
       bag.registry, bag.releaseVersion);

--- a/api/services/microConfig.js
+++ b/api/services/microConfig.js
@@ -177,7 +177,7 @@ function _generateImage(bag, next) {
 
   if (bag.component === 'genExec')
     bag.config.image = util.format('%s/genexec:%s',
-      'shipimg', bag.releaseVersion);
+      'drydock', bag.releaseVersion);
   else
     bag.config.image = util.format('%s/micro:%s',
       bag.registry, bag.releaseVersion);

--- a/common/scripts/configs/default_system_machine_image.sql.template
+++ b/common/scripts/configs/default_system_machine_image.sql.template
@@ -5,7 +5,7 @@ do $$
        "isAvailable", "isDefault", "region", "keyName", "runShImage",  "securityGroup",
        "subnetId", "drydockTag", "drydockFamily", "createdBy", "updatedBy", "createdAt", "updatedAt")
      values ('572c81cb39a5440c0031b61c', 'ami-abcdefgh', 'AWS', 'Stable', 'Stable AMI',
-       true, true, 'us-east-1', 'shippable-beta', 'shipimg/genexec:<%= obj.releaseVersion %>', 'sg-123456',
+       true, true, 'us-east-1', 'shippable-beta', 'drydock/genexec:<%= obj.releaseVersion %>', 'sg-123456',
        '', 'prod', 'u14', '540e55445e5bad6f98764522', '540e55445e5bad6f98764522', '2016-02-29T00:00:00Z', '2016-02-29T00:00:00Z');
     end if;
   end

--- a/common/scripts/configs/default_system_machine_image.sql.template
+++ b/common/scripts/configs/default_system_machine_image.sql.template
@@ -5,7 +5,7 @@ do $$
        "isAvailable", "isDefault", "region", "keyName", "runShImage",  "securityGroup",
        "subnetId", "drydockTag", "drydockFamily", "createdBy", "updatedBy", "createdAt", "updatedAt")
      values ('572c81cb39a5440c0031b61c', 'ami-abcdefgh', 'AWS', 'Stable', 'Stable AMI',
-       true, true, 'us-east-1', 'shippable-beta', 'drydock/genexec:<%= obj.releaseVersion %>', 'sg-123456',
+       true, true, 'us-east-1', 'shippable-beta', '<%= obj.publicRegistry %>/genexec:<%= obj.releaseVersion %>', 'sg-123456',
        '', 'prod', 'u14', '540e55445e5bad6f98764522', '540e55445e5bad6f98764522', '2016-02-29T00:00:00Z', '2016-02-29T00:00:00Z');
     end if;
   end

--- a/common/scripts/lib/_helpers.sh
+++ b/common/scripts/lib/_helpers.sh
@@ -182,7 +182,7 @@ __pull_images() {
 
   __process_msg "Registry: shipimg"
   
-  image="shipimg/genexec:$RELEASE"
+  image="drydock/genexec:$RELEASE"
   __process_msg "Pulling $image"
   sudo docker pull $image
 

--- a/common/scripts/lib/_helpers.sh
+++ b/common/scripts/lib/_helpers.sh
@@ -182,7 +182,7 @@ __pull_images() {
 
   __process_msg "Registry: shipimg"
   
-  image="drydock/genexec:$RELEASE"
+  image="$PUBLIC_IMAGE_REGISTRY/genexec:$RELEASE"
   __process_msg "Pulling $image"
   sudo docker pull $image
 


### PR DESCRIPTION
Fixes https://github.com/Shippable/admiral/issues/991

* For new installations the images is getting set to drydock instead of shipimg.
* For existing installations users will need to manually update the systemMachineImage from the UI.