### PR TITLE
update list command to show switch option

### DIFF
--- a/common/scripts/lib/_parseArgs.sh
+++ b/common/scripts/lib/_parseArgs.sh
@@ -347,7 +347,7 @@ __print_help() {
 __print_list() {
   printf "\nAvailable Admiral versions are:\n"
   git fetch && git tag
-  printf "\nTo upgrade use: $ sudo ./admiral.sh upgrade <version>\n\n"
+  printf "\nTo switch version use: $ sudo ./admiral.sh switch <version>\n\n"
   exit 0
 }
 


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/1002

as MVP2 was updated to have `switch` command instead of upgrade with tag