### PR TITLE
Updates files to populate the default apiUrlIntegration for services

### DIFF
--- a/api/services/post.js
+++ b/api/services/post.js
@@ -8,6 +8,8 @@ var path = require('path');
 var _ = require('underscore');
 var spawn = require('child_process').spawn;
 var fs = require('fs');
+var defaultServiceSettings =
+  require('../../common/scripts/configs/services.json');
 
 var APIAdapter = require('../../common/APIAdapter.js');
 var envHandler = require('../../common/envHandler.js');
@@ -133,6 +135,16 @@ function _getServiceConfig(bag, next) {
 
       bag.services = config;
       bag.serviceConfig = config[bag.name];
+
+      var defaultApiUrlIntegration =
+        _.findWhere(defaultServiceSettings.serviceConfigs,
+          {name: bag.name}).apiUrlIntegration;
+
+      //bag.reqBody.apiUrlIntegration is added to add support for dynamically
+      //picking up apiUrlIntegration from the UI in the future
+      bag.serviceConfig.apiUrlIntegration = bag.reqBody.apiUrlIntegration ||
+        bag.serviceConfig.apiUrlIntegration || defaultApiUrlIntegration;
+
       return next();
     }
   );


### PR DESCRIPTION
Fixes https://github.com/Shippable/admiral/issues/1063

Same as https://github.com/Shippable/admiral/blob/master/api/services/put.js#L251
This will avoid an additional step to `Save` the `Services` before upgrading the installation in prod.

Verified it locally by installing v5.8.2 and then upgrading it to master without any manual intervention.

```
admiral git:(master) ✗ docker ps | grep jobR
4a6ce60dad41        374168611083.dkr.ecr.us-east-1.amazonaws.com/micro:master   "/home/shippable/m..."    15 seconds ago       Up 14 seconds                                                                        jobRequest
➜  admiral git:(master) ✗ docker inspect 4a6ce60dad41 | grep SHIPPABLE_API_URL
                "SHIPPABLE_API_URL=http://172.17.42.1:50000",
➜  admiral git:(master) ✗ docker inspect 4a6ce60dad41 | grep SHIPPABLE_API_URL
➜  admiral git:(master) ✗ docker ps | grep jobT
2191e4f3a0d9        374168611083.dkr.ecr.us-east-1.amazonaws.com/micro:master   "/home/shippable/m..."    34 seconds ago       Up 34 seconds                                                                        jobTrigger
➜  admiral git:(master) ✗ docker inspect 2191e4f3a0d9 | grep SHIPPABLE_API_URL
                "SHIPPABLE_API_URL=http://b1650cbe.ngrok.io",
➜  admiral git:(master) ✗ docker ps | grep www
d23b98008850        374168611083.dkr.ecr.us-east-1.amazonaws.com/www:master     "/home/shippable/w..."    About a minute ago   Up About a minute                                                                    www
➜  admiral git:(master) ✗ docker inspect d23b98008850 | grep SHIPPABLE_API_URL
                "SHIPPABLE_API_URL=http://localhost:50000",
```