### PR TITLE
Updates files to start internalAPI service

### DIFF
--- a/api/services/put.js
+++ b/api/services/put.js
@@ -257,6 +257,9 @@ function _put(bag, next) {
   bag.serviceConfig.apiUrlIntegration = bag.reqBody.apiUrlIntegration ||
     bag.serviceConfig.apiUrlIntegration || defaultApiUrlIntegration;
 
+  if (_.has(bag.reqBody, 'isEnabled'))
+    bag.serviceConfig.isEnabled = bag.reqBody.isEnabled;
+
   bag.services[bag.name] = bag.serviceConfig;
 
   configHandler.put('services', bag.services,

--- a/static/scripts/dashboard/dashboardCtrl.js
+++ b/static/scripts/dashboard/dashboardCtrl.js
@@ -46,7 +46,9 @@
       globalServices: [
         'api',
         'mktg',
-        'www'
+        'www',
+        'internalAPI',
+        'consoleAPI'
       ],
       initializeForm: {
         secrets: {
@@ -2009,6 +2011,17 @@
       );
     }
 
+    function deleteInternalAPIService(bag,  next) {
+      admiralApiAdapter.deleteService('internalAPI',
+        {isEnabled: $scope.vm.installForm.internalAPI.url.isEnabled},
+        function (err) {
+          if (err)
+            return next(err);
+          return next();
+        }
+      );
+    }
+
     function startAPIService(bag, next) {
       // Start API first because the other services need it
       var apiService = _.findWhere(bag.enabledCoreServices,
@@ -2131,6 +2144,7 @@
           updateProvisionSystemIntegration,
           updateSystemMachineImages,
           startAPI,
+          startInternalAPI,
           startWWW,
           startSync,
           startMktg,
@@ -2201,7 +2215,8 @@
           getMasterIntegrations.bind(null, {}),
           updateProvisionSystemIntegration,
           updateSystemMachineImages,
-          updateFilestoreSystemIntegration
+          updateFilestoreSystemIntegration,
+          updateInternalAPIService
         ],
         function (err) {
           $scope.vm.saving = false;
@@ -2240,6 +2255,7 @@
           getEnabledServices.bind(null, bag),
           deleteAddonServices.bind(null, bag),
           deleteCoreServices.bind(null, bag),
+          deleteInternalAPIService.bind(null, bag),
           startAPIService.bind(null, bag),
           startCoreServices.bind(null, bag),
           startNexecService.bind(null, bag),
@@ -2294,6 +2310,28 @@
       updateSystemIntegration(bag,
         function (err) {
           return next(err);
+        }
+      );
+    }
+
+
+    function updateInternalAPIService(next) {
+      var internalAPIService = {};
+      _.each($scope.vm.allServices,
+        function(service) {
+          if (service.serviceName === 'internalAPI')
+            internalAPIService = service;
+        }
+      );
+
+      internalAPIService.isEnabled =
+        $scope.vm.installForm.internalAPI.url.isEnabled;
+
+      admiralApiAdapter.putService('internalAPI', internalAPIService,
+        function (err) {
+          if (err)
+            horn.error(err);
+          return next();
         }
       );
     }
@@ -2903,6 +2941,18 @@
 
     function startAPI(next) {
       startService('api',
+        function (err) {
+          if (err)
+            return next(err);
+
+          return next();
+        }
+      );
+    }
+
+    function startInternalAPI(next) {
+      if (!$scope.vm.installForm.internalAPI.url.isEnabled) return next();
+      startService('internalAPI',
         function (err) {
           if (err)
             return next(err);

--- a/static/scripts/dashboard/dashboardCtrl.js
+++ b/static/scripts/dashboard/dashboardCtrl.js
@@ -2011,9 +2011,11 @@
       );
     }
 
-    function deleteInternalAPIService(bag,  next) {
-      admiralApiAdapter.deleteService('internalAPI',
-        {isEnabled: $scope.vm.installForm.internalAPI.url.isEnabled},
+    function deleteInternalAPIService(bag, next) {
+      var body = {
+        isEnabled: $scope.vm.installForm.internalAPI.url.isEnabled
+      };
+      admiralApiAdapter.deleteService('internalAPI', body,
         function (err) {
           if (err)
             return next(err);


### PR DESCRIPTION
Fixes https://github.com/Shippable/admiral/issues/1075
Scenarios Tested Locally

### New Installation
 - Entered internalAPI url in new installation and hit Install (creates an internalAPI service)
 - Hit install without entering any internalAPI url integration. (doesn't create internalAPI service)

### Existing Installation
- Entered internalAPI url and hit `Save` (Updates the serviceConfig in db to set isEnabled: true, no service restarts)
- Now hit Restart (internalAPI is booted up at port 50004)

- Removed  internalAPI url and hit `Save` (Updates the serviceConfig in db to set isEnabled: false, no service restarts)
- Now hit Restart (internalAPI is removed)