### PR TITLE
add migration script for adding sshKey masterIntegration and its masterIntegrationFields

### DIFF
--- a/common/scripts/configs/master_integration_fields.sql
+++ b/common/scripts/configs/master_integration_fields.sql
@@ -842,6 +842,17 @@ do $$
       values (227, '596d9b49fa1a3f979c10b5a5', 'password', 'string', true, true, '54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2016-06-01', '2016-06-01');
     end if;
 
+    -- Fields for sshKey integration
+    if not exists (select 1 from "masterIntegrationFields" where "id" = 228) then
+      insert into "masterIntegrationFields" ("id", "masterIntegrationId", "name", "dataType", "isRequired", "isSecure","createdBy", "updatedBy", "createdAt", "updatedAt")
+      values (228, '596d9b49fa1a3f979c10b5a6', 'publicKey', 'string', true, false,'54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2016-06-01', '2016-06-01');
+    end if;
+
+    if not exists (select 1 from "masterIntegrationFields" where "id" = 229) then
+      insert into "masterIntegrationFields" ("id", "masterIntegrationId", "name", "dataType", "isRequired", "isSecure","createdBy", "updatedBy", "createdAt", "updatedAt")
+      values (229, '596d9b49fa1a3f979c10b5a6', 'privateKey', 'string', true, true,'54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2016-06-01', '2016-06-01');
+    end if;
+
     -- END adding master integration fields
 
     -- Remove masterIntegrationFields

--- a/common/scripts/configs/master_integrations.sql
+++ b/common/scripts/configs/master_integrations.sql
@@ -359,6 +359,12 @@ do $$
       values ('596d9b49fa1a3f979c10b5a5', 70, 'gitCredential', 'Git Credential', 'generic', false, 'account', 5012, '54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2016-06-01', '2016-06-01');
     end if;
 
+    -- Add sshKey integration
+    if not exists (select 1 from "masterIntegrations" where "name" = 'sshKey' and "typeCode" = 5012) then
+      insert into "masterIntegrations" ("id", "masterIntegrationId", "name", "displayName", "type", "isEnabled", "level", "typeCode", "createdBy", "updatedBy", "createdAt", "updatedAt")
+      values ('596d9b49fa1a3f979c10b5a6', 71, 'sshKey', 'SSH Key', 'generic', false, 'account', 5012, '54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2016-06-01', '2016-06-01');
+    end if;
+
     -- END adding master integrations
 
     -- Remove masterIntegrations


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/1140,
https://github.com/Shippable/admiral/issues/1141

```yml
shipdb=# select * from "masterIntegrations" where "masterIntegrationId" = 71;
-[ RECORD 1 ]-------+-------------------------
id                  | 596d9b49fa1a3f979c10b5a6
masterIntegrationId | 71
name                | sshKey
type                | generic
typeCode            | 5012
displayName         | SSH Key
isEnabled           | f
isDeprecated        | f
level               | account
createdBy           | 54188262bc4d591ba438d62a
updatedBy           | 54188262bc4d591ba438d62a
createdAt           | 2016-06-01 00:00:00+00
updatedAt           | 2016-06-01 00:00:00+00

shipdb=# select * from "masterIntegrationFields" where "masterIntegrationId" = '596d9b49fa1a3f979c10b5a6';
-[ RECORD 1 ]-------+-------------------------
id                  | 228
masterIntegrationId | 596d9b49fa1a3f979c10b5a6
name                | publicKey
dataType            | string
isRequired          | t
isSecure            | f
createdBy           | 54188262bc4d591ba438d62a
updatedBy           | 54188262bc4d591ba438d62a
createdAt           | 2016-06-01 00:00:00+00
updatedAt           | 2016-06-01 00:00:00+00
-[ RECORD 2 ]-------+-------------------------
id                  | 229
masterIntegrationId | 596d9b49fa1a3f979c10b5a6
name                | privateKey
dataType            | string
isRequired          | t
isSecure            | t
createdBy           | 54188262bc4d591ba438d62a
updatedBy           | 54188262bc4d591ba438d62a
createdAt           | 2016-06-01 00:00:00+00
updatedAt           | 2016-06-01 00:00:00+00

```