### PR TITLE
sshKey addon can be managed in Admiral

### DIFF
--- a/baseMigrations/migrate.js
+++ b/baseMigrations/migrate.js
@@ -897,7 +897,7 @@ function _createSSHKeysSystemIntegration(bag, next) {
 
   var systemIntegration = {
     name: 'sshKeys',
-    masterName: 'ssh-key',
+    masterName: 'sshKey',
     data: {
       publicKey: bag.systemConfig.systemNodePublicKey ||
         bag.stateJson.systemSettings.systemNodePublicKey,

--- a/common/scripts/configs/services.json
+++ b/common/scripts/configs/services.json
@@ -234,6 +234,11 @@
       "services": []
     },
     {
+      "name": "sshKey",
+      "type": "generic",
+      "services": []
+    },
+    {
       "name": "TRIPUB",
       "type": "deploy",
       "services": [

--- a/static/scripts/dashboard/dashboard.html
+++ b/static/scripts/dashboard/dashboard.html
@@ -2482,6 +2482,12 @@
                             </div>
                             <div class="checkbox">
                               <label>
+                                <input type="checkbox" ng-model="vm.addonsForm['ssh-key'].isEnabled">
+                                {{vm.addonsForm['ssh-key'].displayName}} (Key)
+                              </label>
+                            </div>
+                            <div class="checkbox">
+                              <label>
                                 <input type="checkbox" ng-model="vm.addonsForm.DOC.isEnabled">
                                 {{vm.addonsForm.DOC.displayName}}
                               </label>

--- a/static/scripts/dashboard/dashboardCtrl.js
+++ b/static/scripts/dashboard/dashboardCtrl.js
@@ -295,9 +295,9 @@
           }
         },
         sshKeys: {
-          'ssh-key': {
+          'sshKey': {
             isEnabled: true,
-            masterName: 'ssh-key',
+            masterName: 'sshKey',
             data: {
               publicKey: '',
               privateKey: ''
@@ -395,6 +395,10 @@
         'pem-key': {
           displayName: '',
           isEnabled: false
+        },
+        'ssh-key': {
+          displayName: '',
+          isEnabled: true
         },
         'Private Docker Registry': {
           displayName: '',
@@ -821,7 +825,7 @@
           }
         },
         sshKeys: {
-          'ssh-key': {
+          'sshKey': {
             publicKey: '',
             privateKey: ''
           }
@@ -2432,7 +2436,7 @@
 
       var bag = {
         name: 'sshKeys',
-        masterName: $scope.vm.installForm.sshKeys['ssh-key'].masterName,
+        masterName: $scope.vm.installForm.sshKeys['sshKey'].masterName,
         data: {
           publicKey: $scope.vm.machineKeys.publicKey,
           privateKey: $scope.vm.machineKeys.privateKey

--- a/static/scripts/dashboard/dashboardCtrl.js
+++ b/static/scripts/dashboard/dashboardCtrl.js
@@ -33,6 +33,7 @@
       gitlabKeys: 'gitlab'
     };
 
+    var sshKeyMasterName = '';
     $scope.vm = {
       isLoaded: false,
       initializing: false,
@@ -294,16 +295,7 @@
             }
           }
         },
-        sshKeys: {
-          'sshKey': {
-            isEnabled: true,
-            masterName: 'sshKey',
-            data: {
-              publicKey: '',
-              privateKey: ''
-            }
-          }
-        },
+        sshKeys: {},
         www: {
           url: {
             isEnabled: true,
@@ -406,7 +398,7 @@
         },
         'ssh-key': {
           displayName: '',
-          isEnabled: true
+          isEnabled: false
         },
         'Private Docker Registry': {
           displayName: '',
@@ -836,12 +828,7 @@
             url: ''
           }
         },
-        sshKeys: {
-          'sshKey': {
-            publicKey: '',
-            privateKey: ''
-          }
-        },
+        sshKeys: {},
         state: {
           gitlabCreds: {
             password: '',
@@ -928,6 +915,25 @@
             return next();
           }
 
+          var sshKeyIntegration =
+            _.findWhere(systemIntegrations, {name: 'sshKeys'});
+          if (sshKeyIntegration) {
+            sshKeyMasterName = sshKeyIntegration.masterName;
+            var sshKeysForm = {
+              isEnabled: true,
+              masterName: sshKeyMasterName,
+              data: {
+                publicKey: '',
+                privateKey: ''
+              }
+            };
+            var sshKeysDefault = {
+              publicKey: '',
+              privateKey: ''
+            };
+            $scope.vm.installForm.sshKeys[sshKeyMasterName] = sshKeysForm;
+            systemIntDataDefaults.sshKeys[sshKeyMasterName] = sshKeysDefault;
+          }
           var apiIntegration =
             _.findWhere(systemIntegrations, {name: 'api'});
 
@@ -2448,7 +2454,7 @@
 
       var bag = {
         name: 'sshKeys',
-        masterName: $scope.vm.installForm.sshKeys['sshKey'].masterName,
+        masterName: $scope.vm.installForm.sshKeys[sshKeyMasterName].masterName,
         data: {
           publicKey: $scope.vm.machineKeys.publicKey,
           privateKey: $scope.vm.machineKeys.privateKey


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/1157,
https://github.com/Shippable/admiral/issues/1158,
https://github.com/Shippable/admiral/issues/1159


Verified locally when `sshKeys` was already using `ssh-key`,
steps followed:
copied state.json to baseMigrations and ran:
```
$ sudo docker run -v /home/ubuntu/admiral:/home/shippable/admiral/ -v /etc/shippable:/etc/shippable drydock/microbase:master sh -c 'cd /home/shippable/admiral/baseMigrations && node --version && cd .. && npm install && cd - && npm install && node migrate.js'
```
In this case, it dint create a new shhKeys sysInt using `sshKey` int

![screenshot from 2017-10-10 12 09 51](https://user-images.githubusercontent.com/18304961/31372566-04a60d2a-adb4-11e7-8754-7f018f191156.png)

