### PR TITLE
add hipchatKey masterIntegrationFields

### DIFF
--- a/common/scripts/configs/master_integration_fields.sql
+++ b/common/scripts/configs/master_integration_fields.sql
@@ -895,6 +895,12 @@ do $$
       values (238, '580ee981a337bd12008fc43f', 'accessToken', 'string', true, false,'54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2017-10-04', '2017-10-04');
     end if;
 
+    -- masterIntegrationFields for hipchatKey
+    if not exists (select 1 from "masterIntegrationFields" where "id" = 239) then
+      insert into "masterIntegrationFields" ("id", "masterIntegrationId", "name", "dataType", "isRequired", "isSecure","createdBy", "updatedBy", "createdAt", "updatedAt")
+      values (239, '59df56e9b3a7f6d8361c226a', 'token', 'string', true, false,'54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2017-10-12', '2017-10-12');
+    end if;
+
     -- END adding master integration fields
 
     -- Remove masterIntegrationFields

--- a/common/scripts/configs/master_integrations.sql
+++ b/common/scripts/configs/master_integrations.sql
@@ -386,7 +386,7 @@ do $$
     -- adds hipchatKey integration
     if not exists (select 1 from "masterIntegrations" where "name" = 'hipchatKey' and "typeCode" = 5012) then
       insert into "masterIntegrations" ("id", "masterIntegrationId", "name", "displayName", "type", "isEnabled", "level", "typeCode", "createdBy", "updatedBy", "createdAt", "updatedAt")
-      values ('59df56e9b3a7f6d8361c226a', 75, 'hipchatKey', 'HipChat', 'generic', false, 'account', 5012, '54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2017-10-12', '2016-06-12');
+      values ('59df56e9b3a7f6d8361c226a', 75, 'hipchatKey', 'HipChat', 'generic', false, 'account', 5012, '54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2017-10-12', '2017-10-12');
     end if;
 
     -- END adding master integrations


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/1185

adds `token` as masterIntegrationField to hipchatKey

```
shipdb=# select * from  "masterIntegrations" where  name='hipchatKey';
-[ RECORD 1 ]-------+-------------------------
id                  | 59df56e9b3a7f6d8361c226a
masterIntegrationId | 75
name                | hipchatKey
type                | generic
typeCode            | 5012
displayName         | HipChat
isEnabled           | f
isDeprecated        | f
level               | account
createdBy           | 54188262bc4d591ba438d62a
updatedBy           | 54188262bc4d591ba438d62a
createdAt           | 2017-10-12 00:00:00+00
updatedAt           | 2017-10-12 00:00:00+00


shipdb=# select * from "masterIntegrationFields" where "masterIntegrationId" = '59df56e9b3a7f6d8361c226a';
-[ RECORD 1 ]-------+-------------------------
id                  | 239
masterIntegrationId | 59df56e9b3a7f6d8361c226a
name                | token
dataType            | string
isRequired          | t
isSecure            | f
createdBy           | 54188262bc4d591ba438d62a
updatedBy           | 54188262bc4d591ba438d62a
createdAt           | 2017-10-12 00:00:00+00
updatedAt           | 2017-10-12 00:00:00+00

```