### PR TITLE
enabling/disabling of gcloudKey can be managed from admiral

### DIFF
--- a/static/scripts/dashboard/dashboard.html
+++ b/static/scripts/dashboard/dashboard.html
@@ -2506,6 +2506,12 @@
                             </div>
                             <div class="checkbox">
                               <label>
+                                <input type="checkbox" ng-model="vm.addonsForm.gcloudKey.isEnabled">
+                                {{vm.addonsForm.gcloudKey.displayName}} (Generic)
+                              </label>
+                            </div>
+                            <div class="checkbox">
+                              <label>
                                 <input type="checkbox" ng-model="vm.addonsForm.MAZ.isEnabled">
                                 {{vm.addonsForm.MAZ.displayName}}
                               </label>

--- a/static/scripts/dashboard/dashboardCtrl.js
+++ b/static/scripts/dashboard/dashboardCtrl.js
@@ -364,6 +364,10 @@
           displayName: '',
           isEnabled: false
         },
+        gcloudKey: {
+          displayName: '',
+          isEnabled: false
+        },
         GKE: {
           displayName: '',
           isEnabled: false


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/1195
#1196 
Tested by:
 - On clicking the checkbox for gcloudKey, the gcloudKey masterIntegration was getting enabled/disabled
 - If gcloudKey was enabled, It was showing in the dropdown while adding accountIntegration from the UI.
 - If the glcoudKey was disabled, it was not showing in the dropdown while adding an accountIntegration