### PR TITLE
update admiral to populate operatingSystems with values

### DIFF
--- a/api/db/post.js
+++ b/api/db/post.js
@@ -44,6 +44,7 @@ function post(req, res) {
       _generateServiceUserToken.bind(null, bag),
       _setServiceUserToken.bind(null, bag),
       _upsertSystemCodes.bind(null, bag),
+      _upsertOperatingSystems.bind(null, bag),
       _upsertMasterIntegrations.bind(null, bag),
       _upsertMasterIntegrationFields.bind(null, bag),
       _upsertSystemIntegrations.bind(null, bag),
@@ -276,6 +277,33 @@ function _upsertSystemCodes(bag, next) {
       script: '',
       scriptPath: 'create_system_codes.sh',
       tmpScriptFilename: '/tmp/systemCodes.sh',
+      scriptEnvs: {
+        'RUNTIME_DIR': global.config.runtimeDir,
+        'CONFIG_DIR': global.config.configDir,
+        'SCRIPTS_DIR': global.config.scriptsDir,
+        'DBUSERNAME': global.config.dbUsername,
+        'DBNAME': global.config.dbName,
+        'DBHOST': global.config.dbHost,
+        'DBPORT': global.config.dbPort,
+        'DBPASSWORD': global.config.dbPassword
+      }
+    },
+    function (err) {
+      return next(err);
+    }
+  );
+}
+
+function _upsertOperatingSystems(bag, next) {
+  var who = bag.who + '|' + _upsertOperatingSystems.name;
+  logger.verbose(who, 'Inside');
+
+  _copyAndRunScript({
+      who: who,
+      params: {},
+      script: '',
+      scriptPath: 'create_operating_systems.sh',
+      tmpScriptFilename: '/tmp/operatingSystems.sh',
       scriptEnvs: {
         'RUNTIME_DIR': global.config.runtimeDir,
         'CONFIG_DIR': global.config.configDir,

--- a/common/scripts/configs/operating_systems.sql
+++ b/common/scripts/configs/operating_systems.sql
@@ -1,0 +1,40 @@
+do $$
+  begin
+
+    if not exists (select 1 from information_schema.columns where table_name = 'operatingSystems') then
+    -- This is the base table, do not add any fields here. Add them below.
+      create table "operatingSystems" (
+        "id" SERIAL PRIMARY KEY,
+        "code" INT NOT NULL,
+        "name" VARCHAR(255) NOT NULL,
+        "archTypeCode" INT NOT NULL,
+        "createdBy" VARCHAR(24) NOT NULL,
+        "updatedBy" VARCHAR(24) NOT NULL,
+        "createdAt" timestamp with time zone NOT NULL,
+        "updatedAt" timestamp with time zone NOT NULL
+      );
+    end if;
+
+    -- Add operatingSystemCodeArchTypeCodeU index
+    if not exists (select 1 from pg_indexes where tablename = 'operatingSystems' and indexname = 'operatingSystemCodeArchTypeCodeU') then
+      create unique index "operatingSystemCodeArchTypeCodeU" on "operatingSystems" using btree("code", "archTypeCode");
+    end if;
+
+    -- insert all operatingSystems
+    if not exists (select 1 from "operatingSystems" where code = 10) then
+      insert into "operatingSystems" ("code", "name", "archTypeCode", "createdBy", "updatedBy", "createdAt", "updatedAt")
+      values (10, 'Ubuntu_14.04', 8000, '54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2016-06-01', '2016-06-01');
+    end if;
+
+    if not exists (select 1 from "operatingSystems" where code = 20) then
+      insert into "operatingSystems" ("code", "name", "archTypeCode", "createdBy", "updatedBy", "createdAt", "updatedAt")
+      values (20, 'Ubuntu_16.04', 8000, '54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2016-06-01', '2016-06-01');
+    end if;
+
+    if not exists (select 1 from "operatingSystems" where code = 30) then
+      insert into "operatingSystems" ("code", "name", "archTypeCode", "createdBy", "updatedBy", "createdAt", "updatedAt")
+      values (30, 'Ubuntu_16.04', 8001, '54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2016-06-01', '2016-06-01');
+    end if;
+
+  end
+$$;

--- a/common/scripts/configs/operating_systems.sql
+++ b/common/scripts/configs/operating_systems.sql
@@ -33,7 +33,7 @@ do $$
 
     if not exists (select 1 from "operatingSystems" where code = 30) then
       insert into "operatingSystems" ("code", "name", "archTypeCode", "createdBy", "updatedBy", "createdAt", "updatedAt")
-      values (30, 'Ubuntu_16.04', 8001, '54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2016-06-01', '2016-06-01');
+      values (20, 'Ubuntu_16.04', 8001, '54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2016-06-01', '2016-06-01');
     end if;
 
   end

--- a/common/scripts/create_operating_systems.sh
+++ b/common/scripts/create_operating_systems.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -e
+export COMPONENT="db"
+export DB_DATA_DIR="$RUNTIME_DIR/$COMPONENT/data"
+export DB_CONFIG_DIR="$CONFIG_DIR/$COMPONENT"
+export LOGS_FILE="$RUNTIME_DIR/logs/$COMPONENT.log"
+
+## Write logs of this script to component specific file
+exec &> >(tee -a "$LOGS_FILE")
+
+__validate_db_envs() {
+  __process_msg "Creating operating systems table"
+  __process_msg "DB_DATA_DIR: $DB_DATA_DIR"
+  __process_msg "DB_CONFIG_DIR: $DB_CONFIG_DIR"
+  __process_msg "LOGS_FILE:$LOGS_FILE"
+}
+
+__copy_operating_systems() {
+  __process_msg "Copying operating_systems.sql to db container"
+  local host_location="$SCRIPTS_DIR/configs/operating_systems.sql"
+  local container_location="$CONFIG_DIR/db/operating_systems.sql"
+  sudo cp -vr $host_location $container_location
+
+  __process_msg "Successfully copied operating_systems.sql to db container"
+}
+__upsert_operating_systems() {
+  __process_msg "Upserting operating systems in db"
+
+  local operating_systems_location="$DB_CONFIG_DIR/operating_systems.sql"
+  local upsert_cmd="PGHOST=$DBHOST \
+    PGPORT=$DBPORT \
+    PGDATABASE=$DBNAME \
+    PGUSER=$DBUSERNAME \
+    PGPASSWORD=$DBPASSWORD \
+    psql \
+    -U $DBUSERNAME \
+    -d $DBNAME \
+    -h $DBHOST \
+    -v ON_ERROR_STOP=1 \
+    -f $operating_systems_location"
+
+  eval "$upsert_cmd"
+}
+
+main() {
+  __process_marker "Generating operating systems"
+  __validate_db_envs
+  __copy_operating_systems
+  __upsert_operating_systems
+}
+
+main


### PR DESCRIPTION
 #1201

table created using sequelize(API):

```
shipdb=# \d "operatingSystems";
                                      Table "public.operatingSystems"
    Column    |           Type           |                            Modifiers                            
--------------+--------------------------+-----------------------------------------------------------------
 id           | integer                  | not null default nextval('"operatingSystems_id_seq"'::regclass)
 code         | integer                  | not null
 name         | character varying(255)   | not null
 archTypeCode | integer                  | not null
 createdBy    | character varying(24)    | not null
 updatedBy    | character varying(24)    | not null
 createdAt    | timestamp with time zone | not null
 updatedAt    | timestamp with time zone | not null
Indexes:
    "operatingSystems_pkey" PRIMARY KEY, btree (id, code)
    "operatingSystemCodeArchTypeCodeU" UNIQUE, btree (code, "archTypeCode")
```


table created by Admiral:

```
shipdb=# \d "operatingSystems";
                                      Table "public.operatingSystems"
    Column    |           Type           |                            Modifiers                            
--------------+--------------------------+-----------------------------------------------------------------
 id           | integer                  | not null default nextval('"operatingSystems_id_seq"'::regclass)
 code         | integer                  | not null
 name         | character varying(255)   | not null
 archTypeCode | integer                  | not null
 createdBy    | character varying(24)    | not null
 updatedBy    | character varying(24)    | not null
 createdAt    | timestamp with time zone | not null
 updatedAt    | timestamp with time zone | not null
Indexes:
    "operatingSystems_pkey" PRIMARY KEY, btree (id)
    "operatingSystemCodeArchTypeCodeU" UNIQUE, btree (code, "archTypeCode")
```