### PR TITLE
deprecate ACS integration

### DIFF
--- a/common/scripts/configs/master_integrations.sql
+++ b/common/scripts/configs/master_integrations.sql
@@ -534,5 +534,10 @@ do $$
     if exists (select 1 from "masterIntegrations" where "name" = 'CLUSTER' and "typeCode" = 5002 and "isDeprecated" = false) then
       update "masterIntegrations" set "isDeprecated" = true where "name" = 'CLUSTER' and "typeCode" = 5002;
     end if;
+
+    --- Deprecate Azure Container Service (ACS) integration
+    if exists (select 1 from "masterIntegrations" where "name" = 'ACS' and "typeCode" = 5002 and "isDeprecated" = false) then
+      update "masterIntegrations" set "isDeprecated" = true where "name" = 'ACS' and "typeCode" = 5002;
+    end if;
   end
 $$;


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/1270

tested locally by admiral initialize 

```
-[ RECORD 1 ]-------+-------------------------
id                  | 5723561699ddf70c00be27ed
masterIntegrationId | 13
name                | ACS
type                | deploy
typeCode            | 5002
displayName         | Azure Container Service
isEnabled           | f
isDeprecated        | t
level               | account
createdBy           | 54188262bc4d591ba438d62a
updatedBy           | 54188262bc4d591ba438d62a
createdAt           | 2016-06-01 00:00:00+00
updatedAt           | 2016-06-01 00:00:00+00

```