### PR TITLE
update name to AWS IAM instead of previous Amazon Web Services (IAM)

### DIFF
--- a/common/scripts/configs/master_integrations.sql
+++ b/common/scripts/configs/master_integrations.sql
@@ -427,7 +427,7 @@ do $$
     -- amazonIamRole master integration
     if not exists (select 1 from "masterIntegrations" where "name" = 'amazonIamRole' and "typeCode" = 5002) then
       insert into "masterIntegrations" ("id", "masterIntegrationId", "name", "displayName", "type", "isEnabled", "level", "typeCode", "createdBy", "updatedBy", "createdAt", "updatedAt")
-      values ('59eee00ef7bcf03ff7b62fd0', 81, 'amazonIamRole', 'Amazon Web Services (IAM)', 'deploy', false, 'account', 5002, '54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2017-10-31', '2017-10-31');
+      values ('59eee00ef7bcf03ff7b62fd0', 81, 'amazonIamRole', 'AWS IAM', 'deploy', false, 'account', 5002, '54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2017-10-31', '2017-10-31');
     end if;
 
     -- ddcKey master integration


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/1277

![image](https://user-images.githubusercontent.com/14016521/32214598-6c74b18a-be45-11e7-9dcb-57f8902fa29f.png)

NOTE: dropped the existing awsIamRole masterInt from db including its fields.