### PR TITLE
removes the jenkins integration from the add on panel and remove jSync from the list of services

### DIFF
--- a/common/scripts/configs/services.json
+++ b/common/scripts/configs/services.json
@@ -153,13 +153,6 @@
       ]
     },
     {
-      "name": "Jenkins",
-      "type": "externalci",
-      "services": [
-        "jSync"
-      ]
-    },
-    {
       "name": "KUBERNETES",
       "type": "deploy",
       "services": [
@@ -337,11 +330,6 @@
       "name": "jobTrigger",
       "repository": "micro",
       "isCore": true,
-      "apiUrlIntegration": "internalAPI"
-    },
-    {
-      "name": "jSync",
-      "repository": "micro",
       "apiUrlIntegration": "internalAPI"
     },
     {

--- a/static/scripts/dashboard/dashboard.html
+++ b/static/scripts/dashboard/dashboard.html
@@ -2561,12 +2561,6 @@
                           <div class="col-md-12">
                             <div class="checkbox">
                               <label>
-                                <input type="checkbox" ng-model="vm.addonsForm.Jenkins.isEnabled">
-                                {{vm.addonsForm.Jenkins.displayName}}
-                              </label>
-                            </div>
-                            <div class="checkbox">
-                              <label>
                                 <input type="checkbox" ng-model="vm.addonsForm['pem-key'].isEnabled">
                                 {{vm.addonsForm['pem-key'].displayName}} <span ng-if="vm.addonsForm['pem-key'].isDeprecated" title="This integration has been deprecated. New integrations of this type cannot be created anymore. If enabled, existing integrations can continue to be used. Please use {{vm.addonsForm.pemKey.displayName}} instead.">(Deprecated)
                                 <span class="glyphicon glyphicon-info-sign"></span></span>

--- a/static/scripts/dashboard/dashboardCtrl.js
+++ b/static/scripts/dashboard/dashboardCtrl.js
@@ -407,10 +407,6 @@
           displayName: '',
           isEnabled: false
         },
-        Jenkins: {
-          displayName: '',
-          isEnabled: false
-        },
         KUBERNETES: {
           displayName: '',
           isEnabled: false


### PR DESCRIPTION
#1296 
#1297 
#1298 
https://github.com/Shippable/admiral/issues/1286

- Tested by running admiral in onebox and initiliazing the services. Verified that the jsync microservices was no longer found in the list of services in systemSettings table.
- Also verified that the jenkins integrations is no longer found in the addons panel