### PR TITLE
enable provision service on enabling the generic gcloudKey integrations

### DIFF
--- a/common/scripts/configs/services.json
+++ b/common/scripts/configs/services.json
@@ -122,6 +122,13 @@
       ]
     },
     {
+      "name": "gcloudKey",
+      "type": "generic",
+      "services": [
+        "provision"
+      ]
+    },
+    {
       "name": "gmailCreds",
       "type": "generic",
       "services": [


### PR DESCRIPTION
- on enabling/disabling the gcloudKey integration provision service was brought up/down
https://github.com/Shippable/admiral/issues/1196