### PR TITLE
#1355; skips empty addons systemSettings updates.

### DIFF
--- a/static/scripts/dashboard/dashboardCtrl.js
+++ b/static/scripts/dashboard/dashboardCtrl.js
@@ -3569,6 +3569,8 @@
     function updateAddonsPanelSystemSettings(next) {
       if (!$scope.vm.systemSettingsId) return next();
 
+      if (_.isEmpty($scope.vm.addonsForm.systemSettings)) return next();
+
       var update = $scope.vm.addonsForm.systemSettings;
 
       admiralApiAdapter.putSystemSettings($scope.vm.systemSettingsId, update,


### PR DESCRIPTION
#1355 

Testing by selecting just a few registries (no errors), then enabling AWS IAM (saved the ID).