### PR TITLE
Adds heap 1169 to release notes.

### DIFF
--- a/releaseNotes/master.md
+++ b/releaseNotes/master.md
@@ -4,11 +4,10 @@
 ${RES_VER_DATE}
 
 ## Features
-  - **simple title**: brief description. [link to docs](#).
-      - itemized
-      - list
-      - for details
-      - if necessary
+  - **Azure Container Service (AKS) deployments**: AKS is now supported in deploy jobs.
+      - An Azure Keys integration can be used in a cluster resource to deploy to a cluster in AKS.  See the [cluster documentation](http://docs.shippable.com/platform/workflow/resource/cluster/) for more information.
+      - LoadBalancer resources with an Azure Keys integration used as inputs to a provision job will be provisioned in AKS.  See the [loadBalancer documentation](http://docs.shippable.com/platform/workflow/resource/loadbalancer/) for more information.
+      - The Azure CLI has been updated to version 2.0.21 in runSh jobs.
 
 ## Fixes
   - **Fixes Permissions Checks while creating or deleting a job's coverage and test reports**: We have fixed the bug where users with incorrect permissions were able to create and delete coverage and test reports for a job. After this fix, only users with collaborator and owner access to a project can create and delete coverage and test reports.


### PR DESCRIPTION
Shippable/heap#1169

Adds AKS deployments to the release notes with links to the cluster and loadBalancer documentation.