### PR TITLE
removes segment integration from the addons section and from the list of services

### DIFF
--- a/common/scripts/configs/services.json
+++ b/common/scripts/configs/services.json
@@ -213,13 +213,6 @@
       "services": []
     },
     {
-      "name": "segmentKeys",
-      "type": "generic",
-      "services" : [
-        "segmentListener"
-      ]
-    },
-    {
       "name": "Slack",
       "type": "notification",
       "services": [
@@ -417,11 +410,6 @@
       "repository": "micro",
       "isCore": true,
       "apiUrlIntegration": "api"
-    },
-    {
-      "name": "segmentListener",
-      "repository": "micro",
-      "apiUrlIntegration": "internalAPI"
     },
     {
       "name": "slack",

--- a/static/scripts/dashboard/dashboard.html
+++ b/static/scripts/dashboard/dashboard.html
@@ -2862,29 +2862,6 @@
                                   ng-model="vm.addonsForm.systemIntegrations.payment.data.braintreeEnvironment" ng-disabled="vm.installingAddons"/>
                               </div>
                             </div>
-                            <!-- segment -->
-                            <div class="checkbox" ng-if="vm.addonsForm.systemIntegrations.segment.isEnabled || (vm.admiralEnv.IS_SERVER === false)">
-                              <label>
-                                <input type="checkbox" ng-model="vm.addonsForm.systemIntegrations.segment.isEnabled">
-                                Segment
-                              </label>
-                            </div>
-                            <div class="row" ng-if="vm.addonsForm.systemIntegrations.segment.isEnabled">
-                              <div class="col-md-offset-1 col-md-3">
-                                API Key
-                              </div>
-                              <div class="col-md-8">
-                                <input type="text" class="form-control input-sm" name="segmentApiKey"
-                                  ng-model="vm.addonsForm.systemIntegrations.segment.data.envs.segmentApiKey" ng-disabled="vm.installingAddons"/>
-                              </div>
-                              <div class="col-md-offset-1 col-md-3">
-                                Mktg Key
-                              </div>
-                              <div class="col-md-8">
-                                <input type="text" class="form-control input-sm" name="segmentMktgKey"
-                                  ng-model="vm.addonsForm.systemIntegrations.segment.data.envs.segmentMktgKey" ng-disabled="vm.installingAddons"/>
-                              </div>
-                           </div>
                          </div>
                        </div>
                       </div>

--- a/static/scripts/dashboard/dashboardCtrl.js
+++ b/static/scripts/dashboard/dashboardCtrl.js
@@ -556,17 +556,6 @@
               braintreeEnvironment: '',
               braintreePublicKey: ''
             }
-          },
-          segment: {
-            isEnabled: false,
-            name: 'segment',
-            masterName: 'keyValuePair',
-            data: {
-              envs: {
-                segmentApiKey: '',
-                segmentMktgKey: ''
-              }
-            }
           }
         }
       },
@@ -937,14 +926,6 @@
             braintreePrivateKey: '',
             braintreeEnvironment: '',
             braintreePublicKey: ''
-          }
-        },
-        segment: {
-          keyValuePair: {
-            envs: {
-              segmentApiKey: '',
-              segmentMktgKey: ''
-            }
           }
         }
       };


### PR DESCRIPTION
- removed the segmentListener service by making a call to DELETE api/services/segmentListener, and disabled the segmentListener integration from the add on panel.

on fresh install, segment listener is not listed in the addons panel and in the services list

https://github.com/Shippable/admiral/issues/1454
https://github.com/Shippable/admiral/issues/1452