### PR TITLE
managing of hubspot is removed from admiral

### DIFF
--- a/common/scripts/configs/services.json
+++ b/common/scripts/configs/services.json
@@ -145,13 +145,6 @@
       ]
     },
     {
-      "name": "hubspotToken",
-      "type": "generic",
-      "services": [
-        "hubspotSync"
-      ]
-    },
-    {
       "name": "irc",
       "type": "notification",
       "services": [
@@ -329,11 +322,6 @@
     },
     {
       "name": "hipchat",
-      "repository": "micro",
-      "apiUrlIntegration": "internalAPI"
-    },
-    {
-      "name": "hubspotSync",
       "repository": "micro",
       "apiUrlIntegration": "internalAPI"
     },

--- a/static/scripts/dashboard/dashboard.html
+++ b/static/scripts/dashboard/dashboard.html
@@ -2671,54 +2671,6 @@
                                 {{vm.addonsForm.gitCredential.displayName}}
                               </label>
                             </div>
-                            <!-- hubspot -->
-                            <div class="checkbox" ng-if="vm.addonsForm.systemIntegrations.mktg.isEnabled || (vm.admiralEnv.IS_SERVER === false)">
-                              <label>
-                                <input type="checkbox" ng-model="vm.addonsForm.systemIntegrations.mktg.isEnabled">
-                                Hubspot
-                              </label>
-                            </div>
-                            <div class="row" ng-if="vm.addonsForm.systemIntegrations.mktg.isEnabled">
-                              <div class="col-md-offset-1 col-md-3">
-                                hubspotListId
-                              </div>
-                              <div class="col-md-8">
-                                <input type="number" class="form-control input-sm" name="hubspotListId"
-                                  ng-model="vm.addonsForm.systemSettings.hubspotListId" ng-disabled="vm.installingAddons"/>
-                              </div>
-                            </div>
-                            <div class="row" ng-if="vm.addonsForm.systemIntegrations.mktg.isEnabled">
-                              <div class="col-md-offset-1 col-md-11">
-                                <div class="checkbox">
-                                  <label>
-                                    <input type="checkbox" ng-model="vm.addonsForm.systemSettings.hubspotShouldSimulate">
-                                    hubspotShouldSimulate
-                                  </label>
-                                </div>
-                              </div>
-                            </div>
-                            <div class="row" ng-if="vm.addonsForm.systemIntegrations.mktg.isEnabled">
-                              <div class="col-md-12" ng-if="vm.addonsForm.systemIntegrations.mktg.isEnabled">
-                                <div class="row">
-                                  <div class="col-md-offset-1 col-md-3">
-                                    Hubspot API Endpoint
-                                  </div>
-                                  <div class="col-md-8">
-                                    <input type="text" class="form-control input-sm" name="hubspotApiEndPoint"
-                                      ng-model="vm.addonsForm.systemIntegrations.mktg.data.hubspotApiEndPoint" ng-disabled="vm.installingAddons"/>
-                                  </div>
-                                </div>
-                                <div class="row">
-                                  <div class="col-md-offset-1 col-md-3">
-                                    Hubspot API Token
-                                  </div>
-                                  <div class="col-md-8">
-                                    <input type="text" class="form-control input-sm" name="hubspotApiToken"
-                                      ng-model="vm.addonsForm.systemIntegrations.mktg.data.hubspotApiToken" ng-disabled="vm.installingAddons"/>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
                             <!-- clearbit -->
                             <div class="checkbox" ng-if="vm.addonsForm.systemIntegrations.clearbit.isEnabled || (vm.admiralEnv.IS_SERVER === false)">
                               <label>

--- a/static/scripts/dashboard/dashboardCtrl.js
+++ b/static/scripts/dashboard/dashboardCtrl.js
@@ -407,10 +407,6 @@
           displayName: '',
           isEnabled: false
         },
-        hubspotToken: {
-          displayName: '',
-          isEnabled: false
-        },
         irc: {
           displayName: '',
           isEnabled: false
@@ -520,15 +516,6 @@
             data: {
               accessKey: '',
               secretKey: ''
-            }
-          },
-          mktg: {
-            isEnabled: false,
-            name: 'mktg',
-            masterName: 'hubspotToken',
-            data: {
-              hubspotApiEndPoint: '',
-              hubspotApiToken: ''
             }
           },
           mktgDB: {
@@ -824,10 +811,6 @@
         mktg: {
           url: {
             url: 'http://' + defaultWorkerAddress + ':50002'
-          },
-          hubspotToken: {
-            hubspotApiEndPoint: '',
-            hubspotApiToken: ''
           }
         },
         msg: {


### PR DESCRIPTION
- all places in api and micro which sends msg to hubspot queue is removed.
- have disabled the hubspotSync integration from admiral.
Tested that hubspot integration is no longer found in the addons section in admiral and the hubspotSync service is removed.
https://github.com/Shippable/admiral/issues/1451
#1453 