### PR TITLE
use superUser word instead of admin while enabling customNodesAdminOnly

### DIFF
--- a/static/scripts/dashboard/dashboard.html
+++ b/static/scripts/dashboard/dashboard.html
@@ -1503,7 +1503,7 @@
                           <div class="col-md-offset-1 col-md-11">
                             <div class="checkbox">
                               <input type="checkbox" ng-model="vm.installForm.systemSettings.customNodesAdminOnly" ng-disabled="vm.installing || vm.saving"/>
-                              Restrict custom node creation to admins only
+                              Restrict custom node creation to superUsers only
                             </div>
                           </div>
                         </div>


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/1495

![screenshot from 2018-01-04 11 17 55](https://user-images.githubusercontent.com/18304961/34551537-faceb5d8-f140-11e7-8211-b604e6b1494a.png)
