### PR TITLE
admiral UI - show ignore TLS checkbox 

### DIFF
--- a/static/scripts/dashboard/dashboard.html
+++ b/static/scripts/dashboard/dashboard.html
@@ -867,6 +867,19 @@
                             </div>
                           </div>
                         </div>
+                        <!-- Ignore TLS TODO: add warning popup -->
+                        <div class="col-md-offset-1 col-md-11">
+                          <div>&nbsp;</div>
+                          <div class="row">
+                            <div class="col-md-12">
+                              <div class="checkbox">
+                                <input type="checkbox" ng-model="vm.installForm.ignoreTLSErrors"
+                                  ng-disabled="vm.installing || vm.saving" />
+                                <b> Ignore TLS Errors (optional) </b>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
                         <!-- State -->
                         <div class="col-md-offset-1 col-md-11">
                           <div>&nbsp;</div>


### PR DESCRIPTION
fixes 
https://github.com/Shippable/admiral/issues/1545
https://github.com/Shippable/admiral/issues/1546

![design](https://user-images.githubusercontent.com/1474302/34827096-14af0d0e-f6ff-11e7-95bf-2880cc70f84e.png)

tested by setting and unsetting ignore TLS flag and restarting services.


--- 
- after this PR, will send a fix to load `IGNORE_TLS_ERRORS` env var everytime before posting services. because if ignore tls value is changed, the value doesn't get reflect in admiral's global env.
- then, will add a `warning popup` when ignoreTLS is set to true
 