### PR TITLE
load IGNORE_TLS_ERRORS from admiral.env instead of global variable

### DIFF
--- a/admiral.app.js
+++ b/admiral.app.js
@@ -130,10 +130,13 @@ function _initializeConfig(bag, next) {
   else
     bag.config.runMode = 'production';
 
-  if (bag.env.IGNORE_TLS_ERRORS && bag.env.IGNORE_TLS_ERRORS === 'true')
+  if (bag.env.IGNORE_TLS_ERRORS && bag.env.IGNORE_TLS_ERRORS === 'true') {
+    // disable TLS check for admiral itself
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
     bag.config.ignoreTlsErrors = true;
-  else
+  } else {
     bag.config.ignoreTlsErrors = false;
+  }
 
   if (bag.env.LOGIN_TOKEN)
     bag.config.loginToken = bag.env.LOGIN_TOKEN;

--- a/api/services/mktgConfig.js
+++ b/api/services/mktgConfig.js
@@ -19,6 +19,7 @@ function mktgConfig(params, callback) {
     envs: '',
     mounts: '',
     runCommand: '',
+    ignoreTLSEnv: 'IGNORE_TLS_ERRORS',
     serviceUserTokenEnv: 'SERVICE_USER_TOKEN',
     serviceUserToken: ''
   };
@@ -26,8 +27,10 @@ function mktgConfig(params, callback) {
   bag.who = util.format('mktgConfig|%s', self.name);
   logger.info(bag.who, 'Starting');
 
-  async.series([
+  async.series(
+    [
       _checkInputParams.bind(null, bag),
+      _getIgnoreTLSEnv.bind(null, bag),
       _getServiceUserToken.bind(null, bag),
       _getAPISystemIntegration.bind(null, bag),
       _generateImage.bind(null, bag),
@@ -53,6 +56,26 @@ function _checkInputParams(bag, next) {
   bag.config.serviceName = bag.name;
 
   return next();
+}
+
+function _getIgnoreTLSEnv(bag, next) {
+  var who = bag.who + '|' + _getIgnoreTLSEnv.name;
+  logger.verbose(who, 'Inside');
+
+  envHandler.get(bag.ignoreTLSEnv,
+    function (err, shouldIgnoreTls) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'Cannot get env: ' + bag.ignoreTLSEnv)
+        );
+
+      bag.shouldIgnoreTls = shouldIgnoreTls;
+      logger.debug('Found ignoreTLS env: ', shouldIgnoreTls);
+
+      return next();
+    }
+  );
 }
 
 function _getServiceUserToken(bag, next) {
@@ -139,7 +162,7 @@ function _generateEnvs(bag, next) {
   envs = util.format('%s -e %s=%s',
     envs, 'SHIPPABLE_API_URL', apiUrl);
 
-  if (global.config.ignoreTlsErrors)
+  if (bag.shouldIgnoreTls && bag.shouldIgnoreTls === 'true')
     envs = util.format('%s -e %s=%s', envs, 'NODE_TLS_REJECT_UNAUTHORIZED', 0);
 
   bag.envs = envs;

--- a/api/services/nexecConfig.js
+++ b/api/services/nexecConfig.js
@@ -19,6 +19,7 @@ function nexecConfig(params, callback) {
     envs: '',
     mounts: '',
     runCommand: '',
+    ignoreTLSEnv: 'IGNORE_TLS_ERRORS',
     serviceUserTokenEnv: 'SERVICE_USER_TOKEN',
     serviceUserToken: ''
   };
@@ -26,8 +27,10 @@ function nexecConfig(params, callback) {
   bag.who = util.format('nexecConfig|%s', self.name);
   logger.info(bag.who, 'Starting');
 
-  async.series([
+  async.series(
+    [
       _checkInputParams.bind(null, bag),
+      _getIgnoreTLSEnv.bind(null, bag),
       _getServiceUserToken.bind(null, bag),
       _getAPISystemIntegration.bind(null, bag),
       _getMsgSystemIntegration.bind(null, bag),
@@ -54,6 +57,26 @@ function _checkInputParams(bag, next) {
   bag.config.serviceName = bag.name;
 
   return next();
+}
+
+function _getIgnoreTLSEnv(bag, next) {
+  var who = bag.who + '|' + _getIgnoreTLSEnv.name;
+  logger.verbose(who, 'Inside');
+
+  envHandler.get(bag.ignoreTLSEnv,
+    function (err, shouldIgnoreTls) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'Cannot get env: ' + bag.ignoreTLSEnv)
+        );
+
+      bag.shouldIgnoreTls = shouldIgnoreTls;
+      logger.debug('Found ignoreTLS env: ', shouldIgnoreTls);
+
+      return next();
+    }
+  );
 }
 
 function _getServiceUserToken(bag, next) {
@@ -189,7 +212,7 @@ function _generateEnvs(bag, next) {
   envs = util.format('%s -e %s=%s',
     envs, 'SHIPPABLE_AMQP_DEFAULT_EXCHANGE', amqpDefaultExchange);
 
-  if (global.config.ignoreTlsErrors)
+  if (bag.shouldIgnoreTls && bag.shouldIgnoreTls === 'true')
     envs = util.format('%s -e %s=%s', envs, 'NODE_TLS_REJECT_UNAUTHORIZED', 0);
 
   bag.envs = envs;


### PR DESCRIPTION
tested locally by enabling and disabling checkbox to ignore TLS errors and checking if env var `NODE_TLS_REJECT_UNAUTHORIZED=0` in container
- also disable TLS for admiral service itself. 

fixes
https://github.com/Shippable/admiral/issues/1540
https://github.com/Shippable/admiral/issues/1541
https://github.com/Shippable/admiral/issues/1542
https://github.com/Shippable/admiral/issues/1543