### PR TITLE
#1686; adds updated run coverage to release notes.

### DIFF
--- a/releaseNotes/master.md
+++ b/releaseNotes/master.md
@@ -11,11 +11,10 @@ ${RES_VER_DATE}
   - **Left navbar missing subscription heading**: Display the subscription heading on the navigation menu to make the UI consistent.
   - **Environment variables for resources starting with numbers**: Exporting environment variables for Assembly Line resources with names that start with a number will no longer fail.
       - The leading numbers will be removed to create a valid environment variable key.  The environment variables may now be used in templated resources or in an unmanaged job.
+  - **Coverage results for a run included jobs with no coverage**: Jobs with no coverage results will not be included when calculating the coverage results for the run.
+      - The overall coverage results for the run will be the average of the jobs in the matrix that have coverage results.
 
 ## Custom Nodes
-  - **simple title**: brief description
-      - additional details or
-      - actions required
   - **Environment variables for resources starting with numbers**: Environment variables for jobs and resources with names that start with a number in runSh and runCI will no longer fail.
       - The leading numbers will be removed to create a valid environment variable key.
       - Custom nodes must be reinitialized to use the environment variables for resources with names that start with a number.


### PR DESCRIPTION
#1686 

Coverage results for the run no longer include jobs with no coverage.