### PR TITLE
adds correct ip validation

### DIFF
--- a/common/scripts/lib/_helpers.sh
+++ b/common/scripts/lib/_helpers.sh
@@ -319,7 +319,7 @@ __set_secret_key() {
 _validate_ip() {
   local ip=$1
   local rx='([1-9]?[0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])'
-  [[ $ip =~ (http(s)?://)?([a-zA-Z]+(\.[a-zA-Z0-9]+)+.*)$ ||  $ip =~ ^$rx\.$rx\.$rx\.$rx$ ]];
+  [[ $ip =~ ^(http(s)?://)?([a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+[a-zA-Z0-9/?]*)$ ||  $ip =~ ^$rx\.$rx\.$rx\.$rx$ ]];
 }
 
 __set_admiral_ip() {


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/1724

tested that valid ip's are:
http(s)://example.com
http(s)://www.example.com
http(s)://example.com/foo
www.example.com
foo.bar.com
1.2.foo.com
foo.12.bar
foo123.bar.com
foo.bar123h.com
localhost

invalid are 800:800:800:900
a.b.1.*
my-website/com/foo
