### PR TITLE
add runtime templates for v6.1.4 release

### DIFF
--- a/migrations/migrations.sql
+++ b/migrations/migrations.sql
@@ -4641,7 +4641,7 @@ do $$
       -- x86_64 Ubuntu_14.04 v6.1.4
       if not exists (select 1 from "runtimeTemplates" where "archTypeCode" = 8000 and "osTypeCode" = 9000 and "version" = 'v6.1.4') then
         insert into "runtimeTemplates" ("archTypeCode", "osTypeCode", "version", "drydockOrg", "drydockFamily", "drydockTag", "defaultTaskImage", "reqProcImage", "isDefault", "createdAt", "updatedAt")
-        values (8000, 9000, 'v6.1.4', 'drydock', 'u16', 'v6.1.4', 'microbase', 'reqproc', true, '2018-01-24', '2017-12-19');
+        values (8000, 9000, 'v6.1.4', 'drydock', 'u16', 'v6.1.4', 'microbase', 'reqproc', true, '2018-01-24', '2018-01-24');
       end if;
 
       -- x86_64 Ubuntu_16.04 Stable
@@ -4706,7 +4706,7 @@ do $$
       -- x86_64 Ubuntu_16.04 v6.1.4
       if not exists (select 1 from "runtimeTemplates" where "archTypeCode" = 8000 and "osTypeCode" = 9001 and "version" = 'v6.1.4') then
         insert into "runtimeTemplates" ("archTypeCode", "osTypeCode", "version", "drydockOrg", "drydockFamily", "drydockTag", "defaultTaskImage", "reqProcImage", "isDefault", "createdAt", "updatedAt")
-        values (8000, 9001, 'v6.1.4', 'drydock', 'u16', 'v6.1.4', 'microbase', 'reqproc', true, '2018-01-24', '2017-12-19');
+        values (8000, 9001, 'v6.1.4', 'drydock', 'u16', 'v6.1.4', 'microbase', 'reqproc', true, '2018-01-24', '2018-01-24');
       end if;
 
       -- aarch64 Ubuntu_16.04 v5.9.4

--- a/migrations/migrations.sql
+++ b/migrations/migrations.sql
@@ -4630,7 +4630,18 @@ do $$
       -- x86_64 Ubuntu_14.04 v5.10.4
       if not exists (select 1 from "runtimeTemplates" where "archTypeCode" = 8000 and "osTypeCode" = 9000 and "version" = 'v5.10.4') then
         insert into "runtimeTemplates" ("archTypeCode", "osTypeCode", "version", "drydockOrg", "drydockFamily", "drydockTag", "defaultTaskImage", "reqProcImage", "isDefault", "createdAt", "updatedAt")
-        values (8000, 9000, 'v5.10.4', 'drydock', 'u16', 'v5.10.4', 'microbase', 'reqproc', true, '2017-12-19', '2017-12-19');
+        values (8000, 9000, 'v5.10.4', 'drydock', 'u16', 'v5.10.4', 'microbase', 'reqproc', false, '2017-12-19', '2017-12-19');
+      end if;
+
+      -- Make v5.10.4 non-default to make way for v6.1.4
+      if exists (select 1 from "runtimeTemplates" where "archTypeCode" = 8000 and "osTypeCode" = 9000 and "version" = 'v5.10.4' and "isDefault" = true) then
+        update "runtimeTemplates" set "isDefault" = false where "archTypeCode" = 8000 and "osTypeCode" = 9000 and "version" = 'v5.10.4' and "isDefault" = true;
+      end if;
+
+      -- x86_64 Ubuntu_14.04 v6.1.4
+      if not exists (select 1 from "runtimeTemplates" where "archTypeCode" = 8000 and "osTypeCode" = 9000 and "version" = 'v6.1.4') then
+        insert into "runtimeTemplates" ("archTypeCode", "osTypeCode", "version", "drydockOrg", "drydockFamily", "drydockTag", "defaultTaskImage", "reqProcImage", "isDefault", "createdAt", "updatedAt")
+        values (8000, 9000, 'v6.1.4', 'drydock', 'u16', 'v6.1.4', 'microbase', 'reqproc', true, '2018-01-24', '2017-12-19');
       end if;
 
       -- x86_64 Ubuntu_16.04 Stable
@@ -4684,7 +4695,18 @@ do $$
       -- x86_64 Ubuntu_16.04 v5.10.4
       if not exists (select 1 from "runtimeTemplates" where "archTypeCode" = 8000 and "osTypeCode" = 9001 and "version" = 'v5.10.4') then
         insert into "runtimeTemplates" ("archTypeCode", "osTypeCode", "version", "drydockOrg", "drydockFamily", "drydockTag", "defaultTaskImage", "reqProcImage", "isDefault", "createdAt", "updatedAt")
-        values (8000, 9001, 'v5.10.4', 'drydock', 'u16', 'v5.10.4', 'microbase', 'reqproc', true, '2017-12-19', '2017-12-19');
+        values (8000, 9001, 'v5.10.4', 'drydock', 'u16', 'v5.10.4', 'microbase', 'reqproc', false, '2017-12-19', '2017-12-19');
+      end if;
+
+      -- Make v5.10.4 non-default to make way for v6.1.4
+      if exists (select 1 from "runtimeTemplates" where "archTypeCode" = 8000 and "osTypeCode" = 9001 and "version" = 'v5.10.4' and "isDefault" = true) then
+        update "runtimeTemplates" set "isDefault" = false where "archTypeCode" = 8000 and "osTypeCode" = 9001 and "version" = 'v5.10.4' and "isDefault" = true;
+      end if;
+
+      -- x86_64 Ubuntu_16.04 v6.1.4
+      if not exists (select 1 from "runtimeTemplates" where "archTypeCode" = 8000 and "osTypeCode" = 9001 and "version" = 'v6.1.4') then
+        insert into "runtimeTemplates" ("archTypeCode", "osTypeCode", "version", "drydockOrg", "drydockFamily", "drydockTag", "defaultTaskImage", "reqProcImage", "isDefault", "createdAt", "updatedAt")
+        values (8000, 9001, 'v6.1.4', 'drydock', 'u16', 'v6.1.4', 'microbase', 'reqproc', true, '2018-01-24', '2017-12-19');
       end if;
 
       -- aarch64 Ubuntu_16.04 v5.9.4


### PR DESCRIPTION
Shippable/pm#9931

not changing default SMI for aarch64 as haven't changed any languages. 