### PR TITLE
Use version.txt if not in a git directory

### DIFF
--- a/common/scripts/lib/_parseArgs.sh
+++ b/common/scripts/lib/_parseArgs.sh
@@ -20,13 +20,17 @@ __validate_runtime() {
 
   ################## set release   ###############################
   cd $ROOT_DIR
-  local head_sha=$(git symbolic-ref HEAD --short -q)
-  if [ "$head_sha" == "" ]; then
-    ## user has checked out a tag, find latest tag
-    export RELEASE=$(git describe --tags)
+  if [ -d ".git" ]; then
+    local head_sha=$(git symbolic-ref HEAD --short -q)
+    if [ "$head_sha" == "" ]; then
+      ## user has checked out a tag, find latest tag
+      export RELEASE=$(git describe --tags)
+    else
+      ## no tag has been checked out, use master
+      export RELEASE=master
+    fi
   else
-    ## no tag has been checked out, use master
-    export RELEASE=master
+    export RELEASE=$(cat version.txt)
   fi
 
   __process_msg "Using release: $RELEASE"


### PR DESCRIPTION
For #1855 

Tested by creating a fresh `git archive` with the change and running it after extracting it to another directory:

````
$ sudo ./admiral.sh install

--- snip ---

# 10:16:06 #######################################
# Validating runtime
##################################################
|___ Using release: v6.2.2

--- snip ---

````

When in the repo directory on the master branch:

````
# 10:17:04 #######################################
# Validating runtime
##################################################
|___ Using release: master
````

When in the repo directory on the `v6.1.2` branch:

````
# 10:24:34 #######################################
# Validating runtime
##################################################
|___ Using release: v6.1.2
````