### PR TITLE
Simplify nc check

### DIFF
--- a/common/scripts/x86_64/CentOS_7/_helpers.sh
+++ b/common/scripts/x86_64/CentOS_7/_helpers.sh
@@ -413,7 +413,7 @@ __check_service_connection() {
   local service_booted=false
 
   while [ $service_booted != true ] && [ $counter -lt $timeout ]; do
-    if nc -v --send-only </dev/null $host $port &>/dev/null; then
+    if nc $host $port < /dev/null &> /dev/null; then
       __process_msg "$service found"
       sleep 5
       service_booted=true


### PR DESCRIPTION
The various flags aren't really required. We only need to send an EOF to nc
so it doesn't look for it. This also makes the check compatible with Ubuntu 14.04.

https://github.com/Shippable/admiral/issues/1955