### PR TITLE
changes redis.conf file in Ubuntu 16

### DIFF
--- a/common/scripts/x86_64/Ubuntu_16.04/remote/config/redis.conf
+++ b/common/scripts/x86_64/Ubuntu_16.04/remote/config/redis.conf
@@ -150,7 +150,7 @@ dbfilename dump.rdb
 # The Append Only File will also be created inside this directory.
 #
 # Note that you must specify a directory here, not a file name.
-dir ./
+dir /var/lib/redis
 
 ################################# REPLICATION #################################
 


### PR DESCRIPTION
This is required to fix the error
```
MISCONF Redis is configured to save RDB snapshots, but is currently not able to persist on disk. Commands that may modify the data set are disabled. Please check Redis logs for details about the error.
````