### PR TITLE
fixes adding public ssh key bugs

### DIFF
--- a/common/scripts/lib/_parseArgs.sh
+++ b/common/scripts/lib/_parseArgs.sh
@@ -312,17 +312,14 @@ __set_host_services() {
   echo "HOST_SERVICES=true" >> "$ADMIRAL_ENV"
   source "$ADMIRAL_ENV"
 
-  ## add ssh key to host's authorized keys
-  local authorized_keys="/root/.ssh/authorized_keys"
-  local tmp_authorized_keys="/root/.ssh/tmp"
+  # create .ssh dir, if not present
+  local root_ssh_dir="/root/.ssh"
+  mkdir -p "$root_ssh_dir"
+
+  ## add public ssh key to host's authorized keys
+  local authorized_keys="$root_ssh_dir/authorized_keys"
   local ssh_public_key=$(cat "$SSH_PUBLIC_KEY")
-  # remove public key from authorized_keys, if present
-  if grep -v "^$ssh_public_key" "$authorized_keys" > "$tmp_authorized_keys"; then
-    cat "$tmp_authorized_keys" > "$authorized_keys"
-  fi
-  rm -f "$tmp_authorized_keys"
-  # add public key to authorized_keys
-  echo "$ssh_public_key" >> "$authorized_keys"
+  echo "$ssh_public_key" | tee -a "$authorized_keys" &> /dev/null
 }
 
 __parse_args_install() {
@@ -544,8 +541,8 @@ __parse_args() {
     case $key in
       install)
         shift
-        __parse_args_install "$@"
         __generate_ssh_keys
+        __parse_args_install "$@"
         __accept_shippable_license
         ;;
       switch)

--- a/common/scripts/lib/_parseArgs.sh
+++ b/common/scripts/lib/_parseArgs.sh
@@ -308,18 +308,20 @@ __prompt_for_inputs() {
 }
 
 __set_host_services() {
-  sed -i '/^HOST_SERVICES/d' "$ADMIRAL_ENV"
-  echo "HOST_SERVICES=true" >> "$ADMIRAL_ENV"
-  source "$ADMIRAL_ENV"
+  if [ "$HOST_SERVICES" == "true" ]; then
+    sed -i '/^HOST_SERVICES/d' "$ADMIRAL_ENV"
+    echo "HOST_SERVICES=true" >> "$ADMIRAL_ENV"
+    source "$ADMIRAL_ENV"
 
-  # create .ssh dir, if not present
-  local root_ssh_dir="/root/.ssh"
-  mkdir -p "$root_ssh_dir"
+    # create .ssh dir, if not present
+    local root_ssh_dir="/root/.ssh"
+    mkdir -p "$root_ssh_dir"
 
-  ## add public ssh key to host's authorized keys
-  local authorized_keys="$root_ssh_dir/authorized_keys"
-  local ssh_public_key=$(cat "$SSH_PUBLIC_KEY")
-  echo "$ssh_public_key" | tee -a "$authorized_keys" &> /dev/null
+    ## add public ssh key to host's authorized keys
+    local authorized_keys="$root_ssh_dir/authorized_keys"
+    local ssh_public_key=$(cat "$SSH_PUBLIC_KEY")
+    echo "$ssh_public_key" | tee -a "$authorized_keys" &> /dev/null
+  fi
 }
 
 __parse_args_install() {
@@ -340,7 +342,7 @@ __parse_args_install() {
           export WITH_PROXY_CONFIG=true
           ;;
         -H|--host_services)
-          __set_host_services
+          export HOST_SERVICES=true
           ;;
         -h|help|--help)
           __print_help_install
@@ -544,6 +546,7 @@ __parse_args() {
         __generate_ssh_keys
         __parse_args_install "$@"
         __accept_shippable_license
+        __set_host_services
         ;;
       switch)
         if [ $# -gt 1 ]; then


### PR DESCRIPTION
1. generate ssh key before parsing install args
2. create /root/.ssh directory if not present(for centos)
3. do not delete public ssh key from authorized keys, if already present. adding same public ssh key multiple times doesn't throw error.

closes https://github.com/Shippable/admiral/issues/2061
https://github.com/Shippable/admiral/issues/2060