### PR TITLE
use db password as state & msg password by default. use port 2222 as …

### DIFF
--- a/static/scripts/dashboard/dashboard2Ctrl.js
+++ b/static/scripts/dashboard/dashboard2Ctrl.js
@@ -1177,21 +1177,31 @@
               $scope.vm.initializeForm[service].rootToken =
                 $scope.vm.admiralEnv.VAULT_TOKEN || '';
             } else if (service === 'msg') {
-              var msgSystemIntegration = _.findWhere($scope.vm.systemIntegrations,
-                {name: 'msg', masterName: 'rabbitmqCreds'});
+              var msgSystemIntegration =
+                _.findWhere($scope.vm.systemIntegrations,
+                  {name: 'msg', masterName: 'rabbitmqCreds'});
               if (msgSystemIntegration) {
                 var auth = msgSystemIntegration.data.amqpUrlRoot.
                   split('@')[0].split('//')[1];
                 $scope.vm.initializeForm[service].username = auth.split(':')[0];
                 $scope.vm.initializeForm[service].password = auth.split(':')[1];
+              } else {
+                if (_.isEmpty($scope.vm.initializeForm[service].password))
+                  $scope.vm.initializeForm[service].password =
+                    $scope.vm.admiralEnv.DB_PASSWORD;
               }
             } else if (service === 'state') {
               var stateSystemIntegration =
                 _.findWhere($scope.vm.systemIntegrations,
                   {name: 'state', masterName: 'gitlabCreds'});
-              if (stateSystemIntegration)
+              if (stateSystemIntegration) {
                 $scope.vm.initializeForm[service].rootPassword =
                   stateSystemIntegration.data.password;
+              } else {
+                if (_.isEmpty($scope.vm.initializeForm[service].rootPassword))
+                  $scope.vm.initializeForm[service].rootPassword =
+                    $scope.vm.admiralEnv.DB_PASSWORD;
+              }
             }
           }
 
@@ -1968,9 +1978,8 @@
 
       // Set the correct port if GitLab has already been initialized,
       // even if it's Shippable managed:
-      if ($scope.vm.systemSettings.state.isInitialized)
-        stateUpdate.sshPort = $scope.vm.initializeForm.state.sshPort ||
-          ($scope.vm.initializeForm.state.initType === 'admiral' ? 2222 : 22);
+      stateUpdate.sshPort = $scope.vm.initializeForm.state.sshPort ||
+        ($scope.vm.admiralEnv.DEV_MODE ? 2222 : 22);
 
       var updateInitializeFormBag = {
         inPostServices: true


### PR DESCRIPTION
…gitlab port, in --dev mode.
https://github.com/Shippable/admiral/issues/2089
https://github.com/Shippable/admiral/issues/2090

test cases
- `./admiral.sh install` on a U16 machine will install all stateful services on host, without user having to enter the password for gitlab and msg
- `./admiral.sh install --dev` on a U16 machine will install all stateful services on containers with letting the users configure the msg and state password