### PR TITLE
docker upgrade should not fail if installed version is not 1.13

### DIFF
--- a/admiral.sh
+++ b/admiral.sh
@@ -45,6 +45,7 @@ source "$LIB_DIR/_helpers.sh"
 
 __bootstrap_admiral_env
 __check_os_and_architecture
+__set_installed_docker_version
 
 source "$SCRIPTS_DIR/$ARCHITECTURE/$OPERATING_SYSTEM/_installVersion.env"
 source "$SCRIPTS_DIR/$ARCHITECTURE/$OPERATING_SYSTEM/_helpers.sh"

--- a/common/scripts/lib/_helpers.sh
+++ b/common/scripts/lib/_helpers.sh
@@ -50,6 +50,14 @@ __check_os_and_architecture() {
   source "$ADMIRAL_ENV"
 }
 
+__set_installed_docker_version() {
+  if command -v "docker" &>/dev/null; then
+    docker_ver=$(docker version --format '{{.Server.Version}}')
+    export INSTALLED_DOCKER_VERSION=$(docker version --format '{{.Server.Version}}')
+    echo "setting INSTALLED_DOCKER_VERSION=$INSTALLED_DOCKER_VERSION"
+  fi
+}
+
 __cleanup() {
   if [ -d $CONFIG_DIR ]; then
     __process_msg "Removing previously created $CONFIG_DIR"

--- a/common/scripts/x86_64/Ubuntu_14.04/_helpers.sh
+++ b/common/scripts/x86_64/Ubuntu_14.04/_helpers.sh
@@ -77,14 +77,10 @@ __check_dependencies() {
   ################## Install Docker  #####################################
   if type docker &> /dev/null && true; then
     __process_msg "'docker' already installed, checking version"
-    local docker_version=$(docker --version)
-    if [[ "$docker_version" == *"$DOCKER_VERSION"* ]]; then
-      __process_msg "'docker' $docker_version installed"
+    if [[ "$INSTALLED_DOCKER_VERSION" == *"$DOCKER_VERSION"* ]]; then
+      __process_msg "'docker' $INSTALLED_DOCKER_VERSION installed"
     else
-      __process_error "Docker version $docker_version installed, required $DOCKER_VERSION"
-      __process_error "Install Docker Version $DOCKER_VERSION from \"
-      https://docs.docker.com/cs-engine/1.13/#install-on-ubuntu-1404-lts-or-1604-lts"
-      exit 1
+      __process_msg "Installed Docker version not same as Admiral's docker version."
     fi
   else
     __process_msg "Docker not installed, installing Docker 1.13"

--- a/common/scripts/x86_64/Ubuntu_14.04/_helpers.sh
+++ b/common/scripts/x86_64/Ubuntu_14.04/_helpers.sh
@@ -80,7 +80,8 @@ __check_dependencies() {
     if [[ "$INSTALLED_DOCKER_VERSION" == *"$DOCKER_VERSION"* ]]; then
       __process_msg "'docker' $INSTALLED_DOCKER_VERSION installed"
     else
-      __process_msg "Installed Docker version not same as Admiral's docker version."
+      __process_msg "Installed Docker version - $INSTALLED_DOCKER_VERSION \
+      not same as expected Docker version - $DOCKER_VERSION."
     fi
   else
     __process_msg "Docker not installed, installing Docker 1.13"
@@ -110,6 +111,7 @@ __check_dependencies() {
     # Install Docker
     chmod +x installDockerScript.sh
     ./installDockerScript.sh
+    __set_installed_docker_version
     rm installDockerScript.sh
   fi
 

--- a/common/scripts/x86_64/Ubuntu_14.04/_helpers.sh
+++ b/common/scripts/x86_64/Ubuntu_14.04/_helpers.sh
@@ -81,7 +81,7 @@ __check_dependencies() {
       __process_msg "'docker' $INSTALLED_DOCKER_VERSION installed"
     else
       __process_msg "Installed Docker version - $INSTALLED_DOCKER_VERSION \
-      not same as expected Docker version - $DOCKER_VERSION."
+      not the same as latest supported version - $DOCKER_VERSION."
     fi
   else
     __process_msg "Docker not installed, installing Docker 1.13"


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/2086
https://github.com/Shippable/admiral/issues/2071

- sets `INSTALLED_DOCKER_VERSION` env on boot and after installing docker
- tested admiral install and upgrade
- shows message if installed docker version is not same as admiral's docker version
