### PR TITLE
fix docker_generate_command

### DIFF
--- a/common/scripts/x86_64/Ubuntu_14.04/_helpers.sh
+++ b/common/scripts/x86_64/Ubuntu_14.04/_helpers.sh
@@ -239,7 +239,7 @@ __registry_login() {
       ecr_cmd="$ecr_cmd --region us-east-1 get-login"
     fi
 
-    docker_login_cmd=$( $ecr_cmd )
+    docker_login_cmd=$( eval "$ecr_cmd" )
     __process_msg "Docker login generated, logging into ecr"
     eval "$docker_login_cmd"
   else

--- a/common/scripts/x86_64/Ubuntu_14.04/remote/installWorker.sh
+++ b/common/scripts/x86_64/Ubuntu_14.04/remote/installWorker.sh
@@ -68,7 +68,7 @@ __registry_login() {
     ecr_cmd="$ecr_cmd --region us-east-1 get-login"
   fi
 
-  docker_login_cmd=$( $ecr_cmd )
+  docker_login_cmd=$( eval "$ecr_cmd" )
   echo "Docker login generated, logging into ecr"
   eval "$docker_login_cmd"
 }

--- a/common/scripts/x86_64/Ubuntu_14.04/startFakeAPI.sh
+++ b/common/scripts/x86_64/Ubuntu_14.04/startFakeAPI.sh
@@ -61,7 +61,7 @@ __docker_login() {
       ecr_cmd="$ecr_cmd --region us-east-1 get-login"
     fi
 
-    docker_login_cmd=$( $ecr_cmd )
+    docker_login_cmd=$( eval "$ecr_cmd" )
 
     __process_msg "Docker login generated, logging into ecr"
     eval "$docker_login_cmd"


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/2088

worked without eval when tested for `initialize` however the command fails while running `upgrade`

tested with admiral upgrade locally. working for eval 