### PR TITLE
bring up services on host network

### DIFF
--- a/api/services/apiConfig.js
+++ b/api/services/apiConfig.js
@@ -249,7 +249,7 @@ function _generateRunCommandCluster(bag, next) {
 
   var opts;
 
-  if (bag.installedDockerVersion === '1.13')
+  if (bag.installedDockerVersion === 1.13)
     opts = util.format(' --publish mode=host,target=%s,published=%s' +
       ',protocol=tcp' +
       ' --network ingress' +
@@ -259,6 +259,7 @@ function _generateRunCommandCluster(bag, next) {
   else
     opts = util.format(' --publish mode=host,target=%s,published=%s' +
       ',protocol=tcp' +
+      ' --network host' +
       ' --mode global' +
       ' --with-registry-auth' +
       ' --endpoint-mode vip', bag.port, bag.port);

--- a/api/services/microConfig.js
+++ b/api/services/microConfig.js
@@ -345,12 +345,13 @@ function _generateRunCommandCluster(bag, next) {
 
   var opts;
 
-  if (bag.installedDockerVersion === '1.13')
+  if (bag.installedDockerVersion === 1.13)
     opts = ' --network ingress' +
       ' --with-registry-auth' +
       ' --endpoint-mode vip';
   else
     opts = ' --with-registry-auth' +
+      ' --network host' +
       ' --endpoint-mode vip';
 
   var runCommand = util.format('docker service create ' +

--- a/api/services/mktgConfig.js
+++ b/api/services/mktgConfig.js
@@ -238,7 +238,7 @@ function _generateRunCommandCluster(bag, next) {
   logger.verbose(who, 'Inside');
 
   var opts;
-  if (bag.installedDockerVersion === '1.13')
+  if (bag.installedDockerVersion === 1.13)
     opts = ' --publish mode=host,target=50002,published=50002,protocol=tcp' +
       ' --network ingress' +
       ' --mode global' +
@@ -247,6 +247,7 @@ function _generateRunCommandCluster(bag, next) {
   else
     opts = ' --publish mode=host,target=50002,published=50002,protocol=tcp' +
       ' --mode global' +
+      ' --network host' +
       ' --with-registry-auth' +
       ' --endpoint-mode vip';
 

--- a/api/services/nexecConfig.js
+++ b/api/services/nexecConfig.js
@@ -291,12 +291,13 @@ function _generateRunCommandCluster(bag, next) {
     replicas = ' --mode global';
 
   var opts;
-  if (bag.installedDockerVersion === '1.13')
+  if (bag.installedDockerVersion === 1.13)
     opts = ' --network ingress' +
     ' --with-registry-auth' +
     ' --endpoint-mode vip';
   else
     opts = ' --with-registry-auth' +
+      ' --network host' +
       ' --endpoint-mode vip';
 
   var runCommand = util.format('docker service create ' +

--- a/api/services/wwwConfig.js
+++ b/api/services/wwwConfig.js
@@ -240,7 +240,7 @@ function _generateRunCommandCluster(bag, next) {
 
   var opts;
 
-  if (bag.installedDockerVersion === '1.13')
+  if (bag.installedDockerVersion === 1.13)
     opts = ' --publish mode=host,target=50001,published=50001,protocol=tcp' +
       ' --network ingress' +
       ' --mode global' +
@@ -249,6 +249,7 @@ function _generateRunCommandCluster(bag, next) {
   else
     opts = ' --publish mode=host,target=50001,published=50001,protocol=tcp' +
       ' --mode global' +
+      ' --network host' +
       ' --with-registry-auth' +
       ' --endpoint-mode vip';
 

--- a/common/scripts/lib/_parseArgs.sh
+++ b/common/scripts/lib/_parseArgs.sh
@@ -132,8 +132,7 @@ __prompt_for_inputs() {
   fi
 
   if [ "$ONEBOX_MODE" == "true" ]; then
-    __get_private_ip
-    ADMIRAL_IP="$PRIVATE_IP"
+    ADMIRAL_IP="127.0.0.1"
     DB_IP="$ADMIRAL_IP"
   fi
 

--- a/common/scripts/x86_64/CentOS_7/_helpers.sh
+++ b/common/scripts/x86_64/CentOS_7/_helpers.sh
@@ -369,9 +369,9 @@ __pull_images_master() {
     else
       # TODO: have a function which returns the docker login command instead of figuring it out everytime
       if [ "$NO_VERIFY_SSL" == true ]; then
-        local docker_login_cmd=$(aws ecr --no-include-email --no-verify-ssl --region us-east-1 get-login)
+        local docker_login_cmd="aws ecr --no-include-email --no-verify-ssl --region us-east-1 get-login | bash"
       else
-        local docker_login_cmd=$(aws ecr --no-include-email --region us-east-1 get-login)
+        local docker_login_cmd="aws ecr --no-include-email --region us-east-1 get-login | bash"
       fi
       __exec_cmd_remote "$master_ip" "$docker_login_cmd"
 
@@ -426,7 +426,11 @@ __pull_images_workers() {
       continue
     fi
 
-    local docker_login_cmd="aws ecr --no-include-email --region us-east-1 get-login | bash"
+    if [ "$NO_VERIFY_SSL" == true ]; then
+      local docker_login_cmd="aws ecr --no-include-email --no-verify-ssl --region us-east-1 get-login | bash"
+    else
+      local docker_login_cmd="aws ecr --no-include-email --region us-east-1 get-login | bash"
+    fi
     __exec_cmd_remote "$host" "$docker_login_cmd"
 
     for image in "${SERVICE_IMAGES[@]}"; do

--- a/common/scripts/x86_64/CentOS_7/_helpers.sh
+++ b/common/scripts/x86_64/CentOS_7/_helpers.sh
@@ -335,12 +335,6 @@ __pull_stateful_service_images() {
     __process_msg "Pulling $image"
     sudo docker pull $image
   done
-
-  for image in "${SERVICE_IMAGES[@]}"; do
-    image="$PRIVATE_IMAGE_REGISTRY/$image:$RELEASE"
-    __process_msg "Pulling $image"
-    sudo docker pull $image
-  done
 }
 
 __pull_admiral_image() {

--- a/common/scripts/x86_64/CentOS_7/_helpers.sh
+++ b/common/scripts/x86_64/CentOS_7/_helpers.sh
@@ -380,7 +380,11 @@ __pull_images_master() {
       sudo docker pull $image
     else
       # TODO: have a function which returns the docker login command instead of figuring it out everytime
-      local docker_login_cmd="aws ecr --no-include-email --region us-east-1 get-login | bash"
+      if [ "$NO_VERIFY_SSL" == true ]; then
+        local docker_login_cmd=$(aws ecr --no-include-email --no-verify-ssl --region us-east-1 get-login)
+      else
+        local docker_login_cmd=$(aws ecr --no-include-email --region us-east-1 get-login)
+      fi
       __exec_cmd_remote "$master_ip" "$docker_login_cmd"
 
       __process_msg "Pulling $image on $master_ip"

--- a/common/scripts/x86_64/CentOS_7/_helpers.sh
+++ b/common/scripts/x86_64/CentOS_7/_helpers.sh
@@ -242,18 +242,6 @@ __set_admiral_ip() {
   fi
 }
 
-__get_private_ip() {
-  export PRIVATE_IP=""
-  local private_ip=""
-  {
-    private_ip=$(ip route get 1)
-  } || return
-  {
-    private_ip=$(echo "$private_ip" | awk '{print $NF;exit}')
-  } || return
-  PRIVATE_IP=$private_ip
-}
-
 __check_existing_database() {
   if [ "$DB_INSTALLED" == "true" ]; then
     __process_marker "Checking database connection"

--- a/common/scripts/x86_64/RHEL_7/_helpers.sh
+++ b/common/scripts/x86_64/RHEL_7/_helpers.sh
@@ -336,12 +336,6 @@ __pull_stateful_service_images() {
     __process_msg "Pulling $image"
     sudo docker pull $image
   done
-
-  for image in "${SERVICE_IMAGES[@]}"; do
-    image="$PRIVATE_IMAGE_REGISTRY/$image:$RELEASE"
-    __process_msg "Pulling $image"
-    sudo docker pull $image
-  done
 }
 
 __pull_admiral_image() {

--- a/common/scripts/x86_64/RHEL_7/_helpers.sh
+++ b/common/scripts/x86_64/RHEL_7/_helpers.sh
@@ -243,18 +243,6 @@ __set_admiral_ip() {
   fi
 }
 
-__get_private_ip() {
-  export PRIVATE_IP=""
-  local private_ip=""
-  {
-    private_ip=$(ip route get 1)
-  } || return
-  {
-    private_ip=$(echo "$private_ip" | awk '{print $NF;exit}')
-  } || return
-  PRIVATE_IP=$private_ip
-}
-
 __check_existing_database() {
   if [ "$DB_INSTALLED" == "true" ]; then
     __process_marker "Checking database connection"

--- a/common/scripts/x86_64/RHEL_7/_helpers.sh
+++ b/common/scripts/x86_64/RHEL_7/_helpers.sh
@@ -427,7 +427,11 @@ __pull_images_workers() {
       continue
     fi
 
-    local docker_login_cmd="aws ecr --no-include-email --region us-east-1 get-login | bash"
+    if [ "$NO_VERIFY_SSL" == true ]; then
+      local docker_login_cmd="aws ecr --no-include-email --no-verify-ssl --region us-east-1 get-login | bash"
+    else
+      local docker_login_cmd="aws ecr --no-include-email --region us-east-1 get-login | bash"
+    fi
     __exec_cmd_remote "$host" "$docker_login_cmd"
 
     for image in "${SERVICE_IMAGES[@]}"; do

--- a/common/scripts/x86_64/Ubuntu_14.04/_helpers.sh
+++ b/common/scripts/x86_64/Ubuntu_14.04/_helpers.sh
@@ -260,12 +260,6 @@ __pull_stateful_service_images() {
     __process_msg "Pulling $image"
     sudo docker pull $image
   done
-
-  for image in "${SERVICE_IMAGES[@]}"; do
-    image="$PRIVATE_IMAGE_REGISTRY/$image:$RELEASE"
-    __process_msg "Pulling $image"
-    sudo docker pull $image
-  done
 }
 
 __pull_admiral_image() {

--- a/common/scripts/x86_64/Ubuntu_14.04/_helpers.sh
+++ b/common/scripts/x86_64/Ubuntu_14.04/_helpers.sh
@@ -478,18 +478,6 @@ __check_connection() {
   __exec_cmd_remote "$host" "echo 'Successfully pinged $host'"
 }
 
-__get_private_ip() {
-  export PRIVATE_IP=""
-  local private_ip=""
-  {
-    private_ip=$(ip route get 1)
-  } || return
-  {
-    private_ip=$(echo "$private_ip" | awk '{print $NF;exit}')
-  } || return
-  PRIVATE_IP=$private_ip
-}
-
 __check_existing_database() {
   if [ "$DB_INSTALLED" == "true" ]; then
     __process_marker "Checking database connection"

--- a/common/scripts/x86_64/Ubuntu_16.04/_helpers.sh
+++ b/common/scripts/x86_64/Ubuntu_16.04/_helpers.sh
@@ -301,9 +301,9 @@ __pull_images_master() {
       sudo docker pull $image
     else
       if [ "$NO_VERIFY_SSL" == true ]; then
-        local docker_login_cmd=$(aws ecr --no-include-email --no-verify-ssl --region us-east-1 get-login)
+        local docker_login_cmd="aws ecr --no-include-email --no-verify-ssl --region us-east-1 get-login | bash"
       else
-        local docker_login_cmd=$(aws ecr --no-include-email --region us-east-1 get-login)
+        local docker_login_cmd="aws ecr --no-include-email --region us-east-1 get-login | bash"
       fi
       __exec_cmd_remote "$master_ip" "$docker_login_cmd"
 
@@ -357,8 +357,11 @@ __pull_images_workers() {
       __process_msg "Images already pulled on admiral host, skipping"
       continue
     fi
-
-    local docker_login_cmd="aws ecr --no-include-email --region us-east-1 get-login | bash"
+    if [ "$NO_VERIFY_SSL" == true ]; then
+      local docker_login_cmd="aws ecr --no-include-email --no-verify-ssl --region us-east-1 get-login | bash"
+    else
+      local docker_login_cmd="aws ecr --no-include-email --region us-east-1 get-login | bash"
+    fi
     __exec_cmd_remote "$host" "$docker_login_cmd"
 
     for image in "${SERVICE_IMAGES[@]}"; do

--- a/common/scripts/x86_64/Ubuntu_16.04/_helpers.sh
+++ b/common/scripts/x86_64/Ubuntu_16.04/_helpers.sh
@@ -469,18 +469,6 @@ __check_connection() {
   __exec_cmd_remote "$host" "echo 'Successfully pinged $host'"
 }
 
-__get_private_ip() {
-  export PRIVATE_IP=""
-  local private_ip=""
-  {
-    private_ip=$(ip route get 1)
-  } || return
-  {
-    private_ip=$(echo "$private_ip" | awk '{print $NF;exit}')
-  } || return
-  PRIVATE_IP=$private_ip
-}
-
 __check_existing_database() {
   if [ "$DB_INSTALLED" == "true" ]; then
     __process_marker "Checking database connection"

--- a/common/scripts/x86_64/Ubuntu_16.04/_helpers.sh
+++ b/common/scripts/x86_64/Ubuntu_16.04/_helpers.sh
@@ -300,7 +300,11 @@ __pull_images_master() {
       __process_msg "Pulling $image"
       sudo docker pull $image
     else
-      local docker_login_cmd="aws ecr --no-include-email --region us-east-1 get-login | bash"
+      if [ "$NO_VERIFY_SSL" == true ]; then
+        local docker_login_cmd=$(aws ecr --no-include-email --no-verify-ssl --region us-east-1 get-login)
+      else
+        local docker_login_cmd=$(aws ecr --no-include-email --region us-east-1 get-login)
+      fi
       __exec_cmd_remote "$master_ip" "$docker_login_cmd"
 
       __process_msg "Pulling $image on $master_ip"


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/2156
this brings up services on `--network host`. So, we don't need the private IP to connect to the machines. We can use localhost to talk to the services.

also, fixed a couple of bugs
- if docker version is 1.13, the ingress network should be used
- if NO_VERIFY_SSL flag is present appropriate docker login command should be used