### PR TITLE
pull images on workers when db is installed on a different machine by admiral

### DIFF
--- a/common/scripts/installDb.sh
+++ b/common/scripts/installDb.sh
@@ -82,6 +82,7 @@ __install_db() {
      __process_msg "Successfully tested connection to $DB_IP $DB_PORT"
   elif [ "$DEV_MODE" == "true" ]; then
     source "$SCRIPTS_DIR/docker/$script_name"
+    DB_INSTALLED="true"
   else
     __check_connection "$DB_IP"
 
@@ -109,6 +110,7 @@ __install_db() {
       DB_DIALECT=$DB_DIALECT \
       $SCRIPTS_DIR_REMOTE/$script_name"
     __exec_cmd_remote "$DB_IP" "$db_install_cmd"
+    DB_INSTALLED="true"
   fi
 }
 

--- a/common/scripts/restart.sh
+++ b/common/scripts/restart.sh
@@ -269,7 +269,9 @@ main() {
     __start_msg
     __start_state
     __start_redis
-    __start_services
+    if [ "$skip_starting_services" != "true" ]; then
+      __start_services
+    fi
   fi
 }
 

--- a/common/scripts/upgrade_docker.sh
+++ b/common/scripts/upgrade_docker.sh
@@ -16,6 +16,15 @@ __check_upgrade_required() {
   fi
 }
 
+__remove_services() {
+  __process_msg "Removing all the services"
+
+  local current_services=$(sudo docker service ls -q)
+  if [ ! -z "$current_services" ]; then
+    sudo docker service rm $current_services || true
+  fi
+}
+
 __create_install_docker_script() {
   if $DOCKER_UPGRADE_REQUIRED; then
     __process_msg "Creating docker install script"
@@ -135,6 +144,7 @@ __restart_admiral() {
 __restart() {
   if $DOCKER_UPGRADE_REQUIRED; then
     IS_RESTART=true
+    export skip_starting_services=true
     source $SCRIPTS_DIR/restart.sh
     IS_RESTART=false
   fi
@@ -144,6 +154,7 @@ main() {
   __process_marker "Upgrading docker"
 
   __check_upgrade_required
+  __remove_services
   __upgrade_docker_version_on_swarm_workers
   __upgrade_docker_version
   __upgrade_awscli_version


### PR DESCRIPTION
This sets DB_INSTALLED as true if db is installed. But this is not setting that value in admiral.env because there might be some funky logic somewhere in the code which might be using the value of `DB_INSTALLED` as false for the case that Shippable has installed the database. Due to time constraint, could not dig further into the code to figure this out.

This also removes services while upgrading docker and doesn't start it. This is just in case that, the services might take time to stop and new services coming up will fail to come up due to port conflicts.

https://github.com/Shippable/admiral/issues/2169

test
- existing installation of admiral which docker 1.13 installed. Upgrade admiral, the docker upgrade happens and everything comes up for the first time.
- `./admiral.sh restart` on the above install
- `./admiral.sh upgrade` on the above install when docker is already upgraded