### PR TITLE
make new ui as default

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -22,10 +22,10 @@ admiral.config(['$stateProvider', '$locationProvider', '$httpProvider',
       }
     );
 
-    $stateProvider.state('dashboard2', {
+    $stateProvider.state('dashboardNew', {
       url: '/',
-      templateUrl: SRC_PATH + 'dashboard/dashboard2.html',
-      controller: 'dashboard2Ctrl'
+      templateUrl: SRC_PATH + 'dashboard/dashboardNew.html',
+      controller: 'dashboardNewCtrl'
     });
 
     $urlRouterProvider.otherwise('/');

--- a/static/scripts/dashboard/dashboard2Ctrl.js
+++ b/static/scripts/dashboard/dashboard2Ctrl.js
@@ -6,6 +6,14 @@
   admiral.controller('dashboard2Ctrl', ['$scope', '$stateParams', '$q', '$state',
     '$interval', '$timeout', 'admiralApiAdapter', 'popup_horn', 'statusCodes',
     dashboard2Ctrl
+  ]).config(['$stateProvider', 'SRC_PATH',
+    function ($stateProvider, SRC_PATH) {
+      $stateProvider.state('dashboard2', {
+        url: '/indexOld',
+        templateUrl: SRC_PATH + 'dashboard/dashboard2.html',
+        controller: 'dashboard2Ctrl'
+      });
+    }
   ]);
 
 

--- a/static/scripts/dashboard/dashboardNewCtrl.js
+++ b/static/scripts/dashboard/dashboardNewCtrl.js
@@ -6,17 +6,7 @@
   admiral.controller('dashboardNewCtrl', ['$scope', '$stateParams', '$q', '$state',
     '$interval', '$timeout', 'admiralApiAdapter', 'popup_horn',
     dashboardNewCtrl
-  ])
-  .config(['$stateProvider', 'SRC_PATH',
-    function ($stateProvider, SRC_PATH) {
-      $stateProvider.state('dashboardNew', {
-        url: '/indexNew',
-        templateUrl: SRC_PATH + 'dashboard/dashboardNew.html',
-        controller: 'dashboardNewCtrl'
-      });
-    }
   ]);
-
 
   function dashboardNewCtrl($scope, $stateParams, $q, $state, $interval, $timeout,
     admiralApiAdapter, popup_horn) {


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/2104
![screenshot from 2018-03-26 10 18 32](https://user-images.githubusercontent.com/18304961/37887401-2259556c-30df-11e8-9689-5769ade0688d.png)

Old ui is on `indexOld`
![screenshot from 2018-03-26 10 18 48](https://user-images.githubusercontent.com/18304961/37887406-2f537626-30df-11e8-9821-0341efc2a62a.png)
