### PR TITLE
update admiral to ask for custom provider name while adding auth providers

### DIFF
--- a/static/scripts/dashboard/dashboardNew.html
+++ b/static/scripts/dashboard/dashboardNew.html
@@ -668,7 +668,7 @@
                                     <div class="form-group">
                                       <label class="col-md-2 control-label">Name (Optional)</label>
                                       <div class="col-md-6">
-                                        <input type="text" class="form-control" name="bitbucketCustomName"
+                                        <input type="text" class="form-control" placeholder="Bitbucket" name="bitbucketCustomName"
                                         ng-model="vm.installForm.auth.bitbucketKeys.data.customName" ng-disabled="vm.installing || vm.saving"/>
                                       </div>
                                     </div>
@@ -748,7 +748,7 @@
                                     <div class="form-group">
                                       <label class="col-md-2 control-label">Name (Optional)</label>
                                       <div class="col-md-6">
-                                        <input type="text" class="form-control" name="bitbucketServerCustomName"
+                                        <input type="text" class="form-control" placeholder="BitBucket Server" name="bitbucketServerCustomName"
                                         ng-model="vm.installForm.auth.bitbucketServerKeys.data.customName" ng-disabled="vm.installing || vm.saving"/>
                                       </div>
                                     </div>
@@ -834,7 +834,7 @@
                                     <div class="form-group">
                                       <label class="col-md-2 control-label">Name (Optional)</label>
                                       <div class="col-md-6">
-                                        <input type="text" class="form-control" name="githubCustomName"
+                                        <input type="text" class="form-control" placeholder="GitHub" name="githubCustomName"
                                         ng-model="vm.installForm.auth.githubKeys.data.customName" ng-disabled="vm.installing || vm.saving"/>
                                       </div>
                                     </div>
@@ -914,7 +914,7 @@
                                     <div class="form-group">
                                       <label class="col-md-2 control-label">Name (Optional)</label>
                                       <div class="col-md-6">
-                                        <input type="text" class="form-control" name="githubEnterpriseCustomName"
+                                        <input type="text" class="form-control" placeholder="GitHub Enterprise" name="githubEnterpriseCustomName"
                                         ng-model="vm.installForm.auth.githubEnterpriseKeys.data.customName" ng-disabled="vm.installing || vm.saving"/>
                                       </div>
                                     </div>
@@ -1001,7 +1001,7 @@
                                     <div class="form-group">
                                       <label class="col-md-2 control-label">Name (Optional)</label>
                                       <div class="col-md-6">
-                                        <input type="text" class="form-control" name="gitlabCustomName"
+                                        <input type="text" class="form-control" placeholder="Gitlab" name="gitlabCustomName"
                                         ng-model="vm.installForm.auth.gitlabKeys.data.customName" ng-disabled="vm.installing || vm.saving"/>
                                       </div>
                                     </div>

--- a/static/scripts/dashboard/dashboardNew.html
+++ b/static/scripts/dashboard/dashboardNew.html
@@ -666,6 +666,13 @@
                                 <div class="col-md-12">
                                   <form class="form-horizontal" role="form">
                                     <div class="form-group">
+                                      <label class="col-md-2 control-label">Name (Optional)</label>
+                                      <div class="col-md-6">
+                                        <input type="text" class="form-control" name="bitbucketCustomName"
+                                        ng-model="vm.installForm.auth.bitbucketKeys.data.customName" ng-disabled="vm.installing || vm.saving"/>
+                                      </div>
+                                    </div>
+                                    <div class="form-group">
                                       <label class="col-md-2 control-label">Client ID</label>
                                       <div class="col-md-6">
                                         <input type="text" class="form-control" name="bitbucketClientId"
@@ -738,6 +745,13 @@
                               <div class="row" ng-if="vm.installForm.auth.bitbucketServerKeys.isEnabled">
                                 <div class="col-md-12">
                                   <form class="form-horizontal" role="form" name="vm.bbsInstallForm" novalidate>
+                                    <div class="form-group">
+                                      <label class="col-md-2 control-label">Name (Optional)</label>
+                                      <div class="col-md-6">
+                                        <input type="text" class="form-control" name="bitbucketServerCustomName"
+                                        ng-model="vm.installForm.auth.bitbucketServerKeys.data.customName" ng-disabled="vm.installing || vm.saving"/>
+                                      </div>
+                                    </div>
                                     <div class="form-group">
                                       <label class="col-md-2 control-label">Client ID</label>
                                       <div class="col-md-6">
@@ -818,6 +832,13 @@
                                 <div class="col-md-12">
                                   <form class="form-horizontal" role="form">
                                     <div class="form-group">
+                                      <label class="col-md-2 control-label">Name (Optional)</label>
+                                      <div class="col-md-6">
+                                        <input type="text" class="form-control" name="githubCustomName"
+                                        ng-model="vm.installForm.auth.githubKeys.data.customName" ng-disabled="vm.installing || vm.saving"/>
+                                      </div>
+                                    </div>
+                                    <div class="form-group">
                                       <label class="col-md-2 control-label">Client ID</label>
                                       <div class="col-md-6">
                                         <input type="text" class="form-control" name="githubClientId"
@@ -890,6 +911,13 @@
                               <div class="row" ng-if="vm.installForm.auth.githubEnterpriseKeys.isEnabled">
                                 <div class="col-md-12">
                                   <form class="form-horizontal" role="form" name="vm.gheInstallForm" novalidate>
+                                    <div class="form-group">
+                                      <label class="col-md-2 control-label">Name (Optional)</label>
+                                      <div class="col-md-6">
+                                        <input type="text" class="form-control" name="githubEnterpriseCustomName"
+                                        ng-model="vm.installForm.auth.githubEnterpriseKeys.data.customName" ng-disabled="vm.installing || vm.saving"/>
+                                      </div>
+                                    </div>
                                     <div class="form-group">
                                       <label class="col-md-2 control-label">Client ID</label>
                                       <div class="col-md-6">
@@ -970,6 +998,13 @@
                               <div class="row" ng-if="vm.installForm.auth.gitlabKeys.isEnabled">
                                 <div class="col-md-12">
                                   <form class="form-horizontal" role="form" name="vm.gitlabInstallForm" novalidate>
+                                    <div class="form-group">
+                                      <label class="col-md-2 control-label">Name (Optional)</label>
+                                      <div class="col-md-6">
+                                        <input type="text" class="form-control" name="gitlabCustomName"
+                                        ng-model="vm.installForm.auth.gitlabKeys.data.customName" ng-disabled="vm.installing || vm.saving"/>
+                                      </div>
+                                    </div>
                                     <div class="form-group">
                                       <label class="col-md-2 control-label">Application ID</label>
                                       <div class="col-md-6">

--- a/static/scripts/dashboard/dashboardNewCtrl.js
+++ b/static/scripts/dashboard/dashboardNewCtrl.js
@@ -312,6 +312,7 @@
             isEnabled: false,
             masterName: 'bitbucketKeys',
             data: {
+              customName: '',
               clientId: '',
               clientSecret: '',
               wwwUrl: '',
@@ -322,6 +323,7 @@
             isEnabled: false,
             masterName: 'bitbucketServerKeys',
             data: {
+              customName: '',
               clientId: '',
               clientSecret: '',
               wwwUrl: '',
@@ -332,6 +334,7 @@
             isEnabled: false,
             masterName: 'githubKeys',
             data: {
+              customName: '',
               clientId: '',
               clientSecret: '',
               wwwUrl: '',
@@ -342,6 +345,7 @@
             isEnabled: false,
             masterName: 'githubEnterpriseKeys',
             data: {
+              customName: '',
               clientId: '',
               clientSecret: '',
               wwwUrl: '',
@@ -352,6 +356,7 @@
             isEnabled: false,
             masterName: 'gitlabKeys',
             data: {
+              customName: '',
               clientId: '',
               clientSecret: '',
               wwwUrl: '',


### PR DESCRIPTION
#2347

![admiral_ui](https://user-images.githubusercontent.com/16793274/39044840-efc4b6d0-44ae-11e8-9bcb-c7e370a5aecd.png)

Tested following for all the providers:
1. admiral admin is able to update custom name in existing systemIntegration
2. admiral admin is able to remove the custom name from existing systemIntegration
3. admiral admin is able provide custom name for a new systemIntegration