### PR TITLE
add bitbucketServerBasicAuth masterIntegration and its fields

### DIFF
--- a/common/scripts/configs/master_integration_fields.sql
+++ b/common/scripts/configs/master_integration_fields.sql
@@ -316,6 +316,22 @@ do $$
       values (278, '577de63321333398d11a1119', 'customName', 'string', false, false,'54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2016-06-01', '2016-06-01');
     end if;
 
+    -- masterIntegrationFields for bitbucketServerBasicAuth
+    if not exists (select 1 from "masterIntegrationFields" where "id" = 282) then
+      insert into "masterIntegrationFields" ("id", "masterIntegrationId", "name", "dataType", "isRequired", "isSecure","createdBy", "updatedBy", "createdAt", "updatedAt")
+      values (282, '577de63321333398d11a1120', 'url', 'string', true, true,'54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2016-06-01', '2016-06-01');
+    end if;
+
+    if not exists (select 1 from "masterIntegrationFields" where "id" = 283) then
+      insert into "masterIntegrationFields" ("id", "masterIntegrationId", "name", "dataType", "isRequired", "isSecure","createdBy", "updatedBy", "createdAt", "updatedAt")
+      values (283, '577de63321333398d11a1120', 'providerId', 'string', false, false,'54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2016-06-01', '2016-06-01');
+    end if;
+
+    if not exists (select 1 from "masterIntegrationFields" where "id" = 284) then
+      insert into "masterIntegrationFields" ("id", "masterIntegrationId", "name", "dataType", "isRequired", "isSecure","createdBy", "updatedBy", "createdAt", "updatedAt")
+      values (284, '577de63321333398d11a1120', 'customName', 'string', false, false,'54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2016-06-01', '2016-06-01');
+    end if;
+
     -- masterIntegrationFields for githubEnterpriseKeys
     if not exists (select 1 from "masterIntegrationFields" where "id" = 187) then
       insert into "masterIntegrationFields" ("id", "masterIntegrationId", "name", "dataType", "isRequired", "isSecure","createdBy", "updatedBy", "createdAt", "updatedAt")

--- a/common/scripts/configs/master_integrations.sql
+++ b/common/scripts/configs/master_integrations.sql
@@ -147,6 +147,12 @@ do $$
       values ('577de63321333398d11a1119', 54, 'bitbucketServerKeys', 'Bitbucket Server Keys', 'generic', false, 'generic', 5012, '54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2016-06-01', '2016-06-01');
     end if;
 
+    -- bitbucketServerBasicAuth master integration
+    if not exists (select 1 from "masterIntegrations" where "name" = 'bitbucketServerBasicAuth' and "typeCode" = 5012) then
+      insert into "masterIntegrations" ("id", "masterIntegrationId", "name", "displayName", "type", "isEnabled", "level", "typeCode", "createdBy", "updatedBy", "createdAt", "updatedAt")
+      values ('577de63321333398d11a1120', 54, 'bitbucketServerBasicAuth', 'Bitbucket Server Basic Auth', 'generic', false, 'generic', 5012, '54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2016-06-01', '2016-06-01');
+    end if;
+
     -- update githubenterpriseKeys to githubEnterpriseKeys
     if exists (select 1 from "masterIntegrations" where "name" = 'githubenterpriseKeys' and "typeCode" = 5012) then
         update "masterIntegrations" set "name" = 'githubEnterpriseKeys' where "name" = 'githubenterpriseKeys' and "typeCode" = 5012;


### PR DESCRIPTION
https://github.com/Shippable/pm/issues/10703

Changes in design:
1. changed `bitbucketServerUrl` to `url` to make consistent with other auth masterIntegrationFields
2. add `providerId` as we need it in www for authStratagies.

masterIntegration
```
  {
    "id": "577de63321333398d11a1120",
    "masterIntegrationId": 54,
    "name": "bitbucketServerBasicAuth",
    "type": "generic",
    "typeCode": 5012,
    "displayName": "Bitbucket Server Basic Auth",
    "isEnabled": false,
    "isDeprecated": false,
    "level": "generic",
    "createdBy": "54188262bc4d591ba438d62a",
    "updatedBy": "54188262bc4d591ba438d62a",
    "createdAt": "2016-06-01T00:00:00.000Z",
    "updatedAt": "2016-06-01T00:00:00.000Z"
  }
```

masterIntegrationFields
```
[
  {
    "id": 284,
    "masterIntegrationId": "577de63321333398d11a1120",
    "name": "customName",
    "dataType": "string",
    "isRequired": false,
    "isSecure": false,
    "createdBy": "54188262bc4d591ba438d62a",
    "updatedBy": "54188262bc4d591ba438d62a",
    "createdAt": "2016-06-01T00:00:00.000Z",
    "updatedAt": "2016-06-01T00:00:00.000Z"
  },
  {
    "id": 283,
    "masterIntegrationId": "577de63321333398d11a1120",
    "name": "providerId",
    "dataType": "string",
    "isRequired": false,
    "isSecure": false,
    "createdBy": "54188262bc4d591ba438d62a",
    "updatedBy": "54188262bc4d591ba438d62a",
    "createdAt": "2016-06-01T00:00:00.000Z",
    "updatedAt": "2016-06-01T00:00:00.000Z"
  },
  {
    "id": 282,
    "masterIntegrationId": "577de63321333398d11a1120",
    "name": "url",
    "dataType": "string",
    "isRequired": true,
    "isSecure": true,
    "createdBy": "54188262bc4d591ba438d62a",
    "updatedBy": "54188262bc4d591ba438d62a",
    "createdAt": "2016-06-01T00:00:00.000Z",
    "updatedAt": "2016-06-01T00:00:00.000Z"
  }
]
```