### PR TITLE
#2380; adds maxNodeCheckInDelayInMinutes.

### DIFF
--- a/common/scripts/configs/system_settings.sql.template
+++ b/common/scripts/configs/system_settings.sql.template
@@ -43,6 +43,7 @@ do $$
         "mktgCTAAggsLastDtTm" timestamp with time zone,
         "defaultMinionInstanceSize" VARCHAR(255),
         "defaultClusterType" VARCHAR(255) NOT NULL DEFAULT 'custom__x86_64__Ubuntu_16.04',
+        "maxNodeCheckInDelayInMinutes" INT NOT NULL DEFAULT 15,
         "createdAt" timestamp with time zone NOT NULL,
         "updatedAt" timestamp with time zone NOT NULL
       );
@@ -102,6 +103,10 @@ do $$
 
     if not exists(select 1 from information_schema.columns where table_name = 'systemSettings' and column_name = 'nodeStopIntervalDays') then
       alter table "systemSettings" add column "nodeStopIntervalDays" INTEGER DEFAULT 30 NOT NULL;
+    end if;
+
+    if not exists (select 1 from information_schema.columns where table_name = 'systemSettings' and column_name = 'maxNodeCheckInDelayInMinutes') then
+      alter table "systemSettings" add column "maxNodeCheckInDelayInMinutes" INTEGER DEFAULT 15 NOT NULL;
     end if;
 
   end

--- a/static/scripts/dashboard/dashboardNew.html
+++ b/static/scripts/dashboard/dashboardNew.html
@@ -2431,6 +2431,19 @@
                                 <hr/>
                               </div>
                             </div>
+                            <div class="row">
+                              <div class="col-md-12">
+                                <form class="form-horizontal" role="form">
+                                  <div class="form-group">
+                                    <label class="col-md-2 control-label">Maximum time between successful node status checks (in minutes):</label>
+                                    <div class="col-md-6">
+                                      <input type="text" class="form-control" name="maxNodeCheckInDelayInMinutes"
+                                        ng-model="vm.installForm.systemSettings.maxNodeCheckInDelayInMinutes" ng-disabled="vm.installing || vm.saving"/>
+                                    </div>
+                                  </div>
+                                </form>
+                              </div>
+                            </div>
                           </div>
                         </div>
                       </div>

--- a/static/scripts/dashboard/dashboardNewCtrl.js
+++ b/static/scripts/dashboard/dashboardNewCtrl.js
@@ -1933,6 +1933,7 @@
             'jobConsoleBufferTimeIntervalMS',
             'apiRetryIntervalMS',
             'accountSyncFrequencyHr',
+            'maxNodeCheckInDelayInMinutes',
             'rootS3Bucket',
             'nodeScriptsLocation',
             'enforcePrivateJobQuota',


### PR DESCRIPTION
#2380 
![screenshot from 2018-04-25 11 47 08](https://user-images.githubusercontent.com/5492015/39268332-676ef776-4884-11e8-9a30-ded9f2d83a23.png)

15 minute default.  Checked that the value has the correct default and can be changed.