### PR TITLE
updates releaseNotes for heap 2219

### DIFF
--- a/releaseNotes/master.md
+++ b/releaseNotes/master.md
@@ -24,27 +24,27 @@ ${RES_VER_DATE}
 
   - Features
       - **Addons are enabled by default in fresh installation of Shippable** - After a [fresh installation of Shippable](http://docs.shippable.com/platform/server/install-onebox/), the following Addons will be enabled by default.
-          - AWS Keys
-          - Azure DC/OS
-          - Azure Keys
-          - Node Cluster
-          - Docker Cloud
-          - Docker DataCenter
-          - Kubernetes
-          - Joyent Triton
-          - Digital Ocean
-          - Google Cloud
-          - Webhook
-          - HipChat
-          - Slack
-          - Jira
-          - AWS Keys (ECR)
-          - JFrog Artifactory
-          - Quay.io
-          - Docker Registry
-          - PEM Key
-          - Key-Value pair
-          - Git Credential
+          - [AWS Keys](http://docs.shippable.com/platform/integration/aws-keys/)
+          - [Azure DC/OS](http://docs.shippable.com/platform/integration/azureDcosKey/)
+          - [Azure Keys](http://docs.shippable.com/platform/integration/azure-keys/)
+          - [Node Cluster](http://docs.shippable.com/platform/integration/nodeCluster/)
+          - [Docker Cloud](http://docs.shippable.com/platform/integration/dclKey/)
+          - [Docker DataCenter](http://docs.shippable.com/platform/integration/ddcKey/)
+          - [Kubernetes](http://docs.shippable.com/platform/integration/kubernetes/)
+          - [Joyent Triton](http://docs.shippable.com/platform/integration/joyentTritonKey/)
+          - [Digital Ocean](http://docs.shippable.com/platform/integration/do/)
+          - [Google Cloud](http://docs.shippable.com/platform/integration/gcloudKey/)
+          - [Webhook](http://docs.shippable.com/platform/integration/webhook/)
+          - [HipChat](http://docs.shippable.com/platform/integration/hipchatKey/)
+          - [Slack](http://docs.shippable.com/platform/integration/slackKey/)
+          - [Jira](http://docs.shippable.com/platform/integration/jira/)
+          - [AWS Keys (ECR)](http://docs.shippable.com/platform/integration/aws-keys/)
+          - [JFrog Artifactory](http://docs.shippable.com/platform/integration/jfrog-artifactoryKey/)
+          - [Quay.io](http://docs.shippable.com/platform/integration/quayLogin/)
+          - [Docker Registry](http://docs.shippable.com/platform/integration/dockerRegistryLogin/)
+          - [PEM Key](http://docs.shippable.com/platform/integration/pemKey/)
+          - [Key-Value pair](http://docs.shippable.com/platform/integration/key-value/)
+          - [Git Credential](http://docs.shippable.com/platform/integration/git-credential/)
 
       - **simple title**: brief description
   - Fixes

--- a/releaseNotes/master.md
+++ b/releaseNotes/master.md
@@ -6,6 +6,29 @@ ${RES_VER_DATE}
 ## Features
   - **Failure logs in email notifications**: Email notifications for both CI and Assembly Lines can be configured to include log output of failing commands with the `sendFailingSnippet` option. To enable this, see the [CI email](http://docs.shippable.com/ci/email-notifications/) or [Assembly Lines configuration](http://docs.shippable.com/platform/workflow/config/#assembly-lines-configuration) documentation.
 
+  - **Addons are enabled by default in fresh installation of Shippable** - After a [fresh installation of Shippable](http://docs.shippable.com/platform/server/install-onebox/), the following Addons will be enabled by default.
+      - AWS Keys
+      - Azure DC/OS
+      - Azure Keys
+      - Node Cluster
+      - Docker Cloud
+      - Docker DataCenter
+      - Kubernetes
+      - Joyent Triton
+      - Digital Ocean
+      - Google Cloud
+      - Webhook
+      - HipChat
+      - Slack
+      - Jira
+      - AWS Keys (ECR)
+      - JFrog Artifactory
+      - Quay.io
+      - Docker Registry
+      - PEM Key
+      - Key-Value pair
+      - Git Credential
+
   - **simple title**: brief description. [link to docs](#).
       - itemized
       - list

--- a/releaseNotes/master.md
+++ b/releaseNotes/master.md
@@ -6,29 +6,6 @@ ${RES_VER_DATE}
 ## Features
   - **Failure logs in email notifications**: Email notifications for both CI and Assembly Lines can be configured to include log output of failing commands with the `sendFailingSnippet` option. To enable this, see the [CI email](http://docs.shippable.com/ci/email-notifications/) or [Assembly Lines configuration](http://docs.shippable.com/platform/workflow/config/#assembly-lines-configuration) documentation.
 
-  - **Addons are enabled by default in fresh installation of Shippable** - After a [fresh installation of Shippable](http://docs.shippable.com/platform/server/install-onebox/), the following Addons will be enabled by default.
-      - AWS Keys
-      - Azure DC/OS
-      - Azure Keys
-      - Node Cluster
-      - Docker Cloud
-      - Docker DataCenter
-      - Kubernetes
-      - Joyent Triton
-      - Digital Ocean
-      - Google Cloud
-      - Webhook
-      - HipChat
-      - Slack
-      - Jira
-      - AWS Keys (ECR)
-      - JFrog Artifactory
-      - Quay.io
-      - Docker Registry
-      - PEM Key
-      - Key-Value pair
-      - Git Credential
-
   - **simple title**: brief description. [link to docs](#).
       - itemized
       - list
@@ -46,6 +23,29 @@ ${RES_VER_DATE}
 ## Shippable Server
 
   - Features
+      - **Addons are enabled by default in fresh installation of Shippable** - After a [fresh installation of Shippable](http://docs.shippable.com/platform/server/install-onebox/), the following Addons will be enabled by default.
+          - AWS Keys
+          - Azure DC/OS
+          - Azure Keys
+          - Node Cluster
+          - Docker Cloud
+          - Docker DataCenter
+          - Kubernetes
+          - Joyent Triton
+          - Digital Ocean
+          - Google Cloud
+          - Webhook
+          - HipChat
+          - Slack
+          - Jira
+          - AWS Keys (ECR)
+          - JFrog Artifactory
+          - Quay.io
+          - Docker Registry
+          - PEM Key
+          - Key-Value pair
+          - Git Credential
+
       - **simple title**: brief description
   - Fixes
       - **simple title**: brief description

--- a/releaseNotes/master.md
+++ b/releaseNotes/master.md
@@ -46,7 +46,6 @@ ${RES_VER_DATE}
           - [Key-Value pair](http://docs.shippable.com/platform/integration/key-value/)
           - [Git Credential](http://docs.shippable.com/platform/integration/git-credential/)
 
-      - **simple title**: brief description
   - Fixes
       - **simple title**: brief description
 


### PR DESCRIPTION
Updates release notes to include the feature added in https://github.com/Shippable/heap/issues/2219

All the links except http://docs.shippable.com/platform/integration/jira/ are working. Seems like the jira documentation link is missing in the [mkdocs.yml file of documentation](https://github.com/Shippable/docs/blob/master/mkdocs.yml). Will open a PR for it too.