### PR TITLE
reset isDuplicateUrl once url is changed

### DIFF
--- a/static/scripts/dashboard/dashboardNewCtrl.js
+++ b/static/scripts/dashboard/dashboardNewCtrl.js
@@ -1483,19 +1483,18 @@
          function () {
           $scope.vm.isNotValidurl[bag.masterName] =
             bag.isNotValidurl[bag.masterName];
-          $scope.vm.disableSave = bag.isNotValidurl[bag.masterName];
-          if (!$scope.vm.disableSave) {
-            var urls = _.filter($scope.vm.installForm.auth,
-              function (auth) {
-                return auth.data.url !==  '' && auth.data.url === bag.url;
-              }
-            );
-            if (urls && urls.length > 1)
-              $scope.vm.isDuplicateUrl[bag.masterName] = true;
-            else
-              $scope.vm.isDuplicateUrl[bag.masterName] = false;
-            $scope.vm.disableSave = $scope.vm.isDuplicateUrl[bag.masterName];
-          }
+          var urls = _.filter($scope.vm.installForm.auth,
+            function (auth) {
+              return auth.data.url !==  '' && auth.data.url === bag.url;
+            }
+          );
+          if (urls && urls.length > 1)
+            $scope.vm.isDuplicateUrl[bag.masterName] = true;
+          else
+            $scope.vm.isDuplicateUrl[bag.masterName] = false;
+
+          $scope.vm.disableSave =  bag.isNotValidurl[bag.masterName] ||
+            $scope.vm.isDuplicateUrl[bag.masterName];
          }
        );
      }


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/2405

Currently if user adds duplicate URLs(while adding BBS Oauth and basic Auth), the error is showing correctly that duplicate urls are not allowed.
But this error doesn't go aways until user adds another valid url. This pr fixes that. If a user tries to edit the url, the duplicate error should go away.