### PR TITLE
adds resourceSubscriptionIdBranch index on resources table

### DIFF
--- a/migrations/migrations.sql
+++ b/migrations/migrations.sql
@@ -809,13 +809,9 @@ do $$
       alter table "resources" add column "branch" varchar(255);
     end if;
 
-    -- Reindex resourceSubscriptionIdNameU to resourceSubscriptionIdNameBranchU in resources table
-    if not exists (select 1 from pg_indexes where tablename = 'resources' and indexname = 'resourceSubscriptionIdNameBranchU') then
-      create unique index "resourceSubscriptionIdNameBranchU" on "resources" using btree("subscriptionId", "name", "branch");
-    end if;
-
-    if exists (select 1 from pg_indexes where tablename = 'resources' and indexname = 'resourceSubscriptionIdNameU') then
-      drop index "resourceSubscriptionIdNameU";
+    -- Add new index resourceSubscriptionIdBranch in resources table
+    if not exists (select 1 from pg_indexes where tablename = 'resources' and indexname = 'resourceSubscriptionIdBranch') then
+      create index "resourceSubscriptionIdBranch" on "resources" using btree("subscriptionId", "branch");
     end if;
 
     -- remove outdated routeRoles


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/2486

 I will execute this command
```
create unique index "resourceSubscriptionIdNameU" on "resources" using btree("subscriptionId", "name");
drop index "resourceSubscriptionIdNameBranchU";
```
before this PR gets merged to make sure table unwanted indexes are gone.