### PR TITLE
#2520;Adds a state type when getting existing config.

### DIFF
--- a/api/state/get.js
+++ b/api/state/get.js
@@ -68,6 +68,10 @@ function _get(bag, next) {
         return next();
       }
 
+      // If there is a state config with no type, assume it's GitLab.
+      if (!state.type)
+        state.type = 'gitlabCreds';
+
       bag.resBody = state;
       return next();
     }


### PR DESCRIPTION
#2520 

Tested installing with GitLab and removing the `type` setting and installing without a state storage location.