### PR TITLE
#2527; migrations from S3 to GitLab.

### DIFF
--- a/api/state/get.js
+++ b/api/state/get.js
@@ -7,6 +7,7 @@ var async = require('async');
 var _ = require('underscore');
 
 var configHandler = require('../../common/configHandler.js');
+var envHandler = require('../../common/envHandler.js');
 
 function get(req, res) {
   var bag = {
@@ -17,7 +18,7 @@ function get(req, res) {
     defaultConfig: {
       address: global.config.admiralIP,
       port: 80,
-      sshPort: 2222,
+      sshPort: 22,
       securePort: 443,
       isShippableManaged: true,
       isInstalled: false,
@@ -31,6 +32,7 @@ function get(req, res) {
   async.series([
     _checkInputParams.bind(null, bag),
     _get.bind(null, bag),
+    _checkDevMode.bind(null, bag),
     _setDefault.bind(null, bag)
   ],
     function (err) {
@@ -74,11 +76,35 @@ function _get(bag, next) {
   );
 }
 
+function _checkDevMode(bag, next) {
+  if (!bag.initializeDefault) return next();
+
+  var who = bag.who + '|' + _checkDevMode.name;
+  logger.verbose(who, 'Inside');
+
+  envHandler.get('DEV_MODE',
+    function (err, devMode) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'Cannot get env: DEV_MODE')
+        );
+
+      bag.devMode = devMode;
+      return next();
+    }
+  );
+}
+
+
 function _setDefault(bag, next) {
   if (!bag.initializeDefault) return next();
 
   var who = bag.who + '|' + _setDefault.name;
   logger.verbose(who, 'Inside');
+
+  if (bag.devMode)
+    bag.defaultConfig.sshPort = 2222;
 
   configHandler.put(bag.component, bag.defaultConfig,
     function (err) {

--- a/api/state/gitlab/createGitLabUsers.js
+++ b/api/state/gitlab/createGitLabUsers.js
@@ -1,0 +1,396 @@
+'use strict';
+
+var self = createGitLabUsers;
+module.exports = self;
+
+var async = require('async');
+var _ = require('underscore');
+var fs = require('fs');
+
+var GitLabAdapter = require('../../../common/GitLabAdapter.js');
+
+function createGitLabUsers(gitlabIntegration, callback) {
+  var bag = {
+    gitlabIntegration: gitlabIntegration
+  };
+
+  bag.who = util.format('state|%s', self.name);
+  logger.verbose(bag.who, 'Starting');
+
+  async.series([
+      _checkInputParams.bind(null, bag),
+      _createAdapter.bind(null, bag),
+      _getLastSubscriptionId.bind(null, bag),
+      _addUsers.bind(null, bag)
+    ],
+    function (err) {
+      logger.verbose(bag.who, 'Completed');
+      if (err)
+        logger.error(err);
+
+      return callback(err);
+    }
+  );
+}
+
+function _checkInputParams(bag, next) {
+  var who = bag.who + '|' + _checkInputParams.name;
+  logger.debug(who, 'Inside');
+
+  if (!bag.gitlabIntegration)
+    return next(
+      new ActErr(who, ActErr.DataNotFound,
+        'SystemIntegration parameter not found :gitlabIntegration')
+    );
+
+  if (!bag.gitlabIntegration.data.url)
+    return next(
+      new ActErr(who, ActErr.DataNotFound,
+        'parameter not found :gitlabIntegration.data.url')
+    );
+
+  if (!bag.gitlabIntegration.data.subscriptionProjectLimit)
+    return next(
+      new ActErr(who, ActErr.DataNotFound,
+        'parameter not found :gitlabIntegration.data.subscriptionProjectLimit')
+    );
+
+  try {
+    bag.subscriptionProjectLimit = parseInt(bag.subscriptionProjectLimit, 10);
+  } catch (exception) {
+    return next(
+      new ActErr(who, ActErr.InvalidParam,
+        'gitlabIntegration.data.subscriptionProjectLimit is not an integer')
+    );
+  }
+
+  if (!bag.gitlabIntegration.data.username)
+    return next(
+      new ActErr(who, ActErr.DataNotFound,
+        'parameter not found :gitlabIntegration.data.username')
+    );
+
+  if (!bag.gitlabIntegration.data.password)
+    return next(
+      new ActErr(who, ActErr.DataNotFound,
+        'parameter not found :gitlabIntegration.data.password')
+    );
+
+  return next();
+}
+
+function _createAdapter(bag, next) {
+  var who = bag.who + '|' + _createAdapter.name;
+  logger.debug(who, 'Inside');
+
+  bag.gitlabAdapter = new GitLabAdapter(null,
+    bag.gitlabIntegration.data.url,
+    bag.gitlabIntegration.data.username, bag.gitlabIntegration.data.password);
+  bag.gitlabAdapter.initialize(
+    function (err) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'initialize returned error', err)
+        );
+
+      return next();
+    }
+  );
+}
+
+function _getLastSubscriptionId(bag, next) {
+  var who = bag.who + '|' + _getLastSubscriptionId.name;
+  logger.verbose(who, 'Inside');
+
+  var query = 'SELECT max("subscriptionId") FROM subscriptions;';
+  global.config.client.query(query,
+    function (err, res) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'Failed to find last subscription with error: ' + util.inspect(err))
+        );
+
+      if (!_.isEmpty(res.rows))
+        bag.lastSubscriptionId = res.rows[0].max;
+
+      return next();
+    }
+  );
+}
+
+function _addUsers(bag, next) {
+  var who = bag.who + '|' + _addUsers.name;
+  logger.verbose(who, 'Inside');
+
+  var nextSubscriptionId = 0;
+  var logStream = fs.createWriteStream(
+    global.config.runtimeDir + '/logs/state.log', {flags:'a'});
+
+  logStream.write(util.format('Subscriptions 1 to %s will be processed\n',
+    bag.lastSubscriptionId));
+
+  async.whilst(
+    function () {
+      return nextSubscriptionId <= bag.lastSubscriptionId;
+    },
+    function (done) {
+      var seriesBag = {
+        nextSubscriptionId: nextSubscriptionId + 1,
+        throughSubscriptionId:
+          _.min([nextSubscriptionId + 50, bag.lastSubscriptionId]),
+        logStream: logStream,
+        gitlabAdapter: bag.gitlabAdapter,
+        gitlabIntegration: bag.gitlabIntegration,
+        who: bag.who,
+        resources: []
+      };
+      async.series([
+          _listSubscriptions.bind(null, seriesBag),
+          _createSubscriptionUsers.bind(null, seriesBag)
+        ],
+        function (err) {
+          nextSubscriptionId = nextSubscriptionId + 50;
+          return done(err);
+        }
+      );
+
+    },
+    function (err) {
+      logStream.end();
+      return next(err);
+    }
+  );
+}
+
+function _listSubscriptions(seriesBag, next) {
+  seriesBag.logStream.write(util.format('Processing subscriptions %s to %s\n',
+    seriesBag.nextSubscriptionId, seriesBag.throughSubscriptionId));
+
+  var query = util.format('SELECT id,"propertyBag","sshPublicKey" ' +
+    'FROM subscriptions WHERE "subscriptionId" BETWEEN %s AND %s;',
+    seriesBag.nextSubscriptionId, seriesBag.throughSubscriptionId);
+  global.config.client.query(query,
+    function (err, res) {
+      if (err)
+        return next(
+          new ActErr('_listSubscriptions', ActErr.OperationFailed,
+            'Failed to find subscriptions with error: ' + util.inspect(err))
+        );
+
+      seriesBag.subscriptions = res.rows;
+      return next();
+    }
+  );
+}
+
+function _createSubscriptionUsers(seriesBag, next) {
+  async.eachSeries(seriesBag.subscriptions,
+    function (subscription, done) {
+      var subSeriesBag = {
+        who: seriesBag.who,
+        subscriptionId: subscription.id,
+        subscriptionPropertyBag: JSON.parse(subscription.propertyBag),
+        subscriptionPublicKey: subscription.sshPublicKey,
+        gitlabAdapter: seriesBag.gitlabAdapter,
+        subscriptionProjectLimit:
+          seriesBag.gitlabIntegration.data.subscriptionProjectLimit,
+        logStream: seriesBag.logStream,
+        userExists: false,
+        groupExists: false,
+        keysExist: false
+      };
+      async.series([
+          _getUser.bind(null, subSeriesBag),
+          _createUser.bind(null, subSeriesBag),
+          _getKeys.bind(null, subSeriesBag),
+          _createUserKey.bind(null, subSeriesBag),
+          _getGroup.bind(null, subSeriesBag),
+          _createSystemGitGroup.bind(null, subSeriesBag),
+          _grantPermission.bind(null, subSeriesBag)
+        ],
+        function (err) {
+          if (err)
+            seriesBag.logStream.write(util.inspect(err) + '\n');
+
+          return done(err);
+        }
+      );
+
+    },
+    function (err) {
+      return next(err);
+    }
+  );
+}
+
+function _getUser(subSeriesBag, next) {
+  var who = subSeriesBag.who + '|' + _getUser.name;
+  logger.debug(who, 'Inside');
+
+  var query = util.format('username=%s',
+    subSeriesBag.subscriptionPropertyBag.nodeUserName);
+  subSeriesBag.gitlabAdapter.getUserByUsername(query,
+    function (err, user) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'getUser returned error', err)
+        );
+
+      if (!_.isEmpty(user)) {
+        subSeriesBag.user = _.first(user);
+        subSeriesBag.userExists = true;
+      }
+      return next();
+    }
+  );
+}
+
+function _createUser(subSeriesBag, next) {
+  if (subSeriesBag.userExists)
+    return next();
+
+  var who = subSeriesBag.who + '|' + _createUser.name;
+  logger.debug(who, 'Inside');
+
+  subSeriesBag.gitlabAdapter.postUser(subSeriesBag.subscriptionId,
+    subSeriesBag.subscriptionPropertyBag.nodeUserName,
+    subSeriesBag.subscriptionPropertyBag.nodePassword,
+    subSeriesBag.subscriptionProjectLimit,
+    function (err, user) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'postUser returned error', err)
+        );
+      subSeriesBag.user = user;
+      if (user.id)
+        subSeriesBag.userExists = true;
+      return next();
+    }
+  );
+}
+
+function _getKeys(subSeriesBag, next) {
+  if (!subSeriesBag.userExists)
+    return next();
+
+  var who = subSeriesBag.who + '|' + _getKeys.name;
+  logger.debug(who, 'Inside');
+
+  subSeriesBag.gitlabAdapter.getKeysByUserId(subSeriesBag.user.id,
+    function (err, sshKeys) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'getKeysByUserId returned error', err)
+        );
+      _.each(sshKeys,
+        function (sshKey) {
+          if (sshKey.key.trim() === subSeriesBag.subscriptionPublicKey.trim())
+            subSeriesBag.keysExist = true;
+        }
+      );
+      return next();
+    }
+  );
+}
+
+function _createUserKey(subSeriesBag, next) {
+  if (subSeriesBag.keysExist)
+    return next();
+
+  var who = subSeriesBag.who + '|' + _createUserKey.name;
+  logger.debug(who, 'Inside');
+
+  subSeriesBag.gitlabAdapter.postUserKey(subSeriesBag.user.id,
+    subSeriesBag.subscriptionPublicKey,
+    function (err) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'postUserKey returned error', err)
+        );
+
+      return next();
+    }
+  );
+}
+
+function _getGroup(subSeriesBag, next) {
+  var who = subSeriesBag.who + '|' + _getGroup.name;
+  logger.debug(who, 'Inside');
+
+  var query = util.format('search=%s', subSeriesBag.subscriptionId);
+
+  subSeriesBag.gitlabAdapter.getGroupByName(query,
+    function (err, group) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'getGroupByName returned error', err)
+        );
+
+      if (!_.isEmpty(group)) {
+        subSeriesBag.groupExists = true;
+        subSeriesBag.group = _.first(group);
+      }
+      return next();
+    }
+  );
+}
+
+function _createSystemGitGroup(subSeriesBag, next) {
+  if (subSeriesBag.groupExists)
+    return next();
+
+  var who = subSeriesBag.who + '|' + _createSystemGitGroup.name;
+  logger.debug(who, 'Inside');
+
+  /* jshint camelcase:false */
+  var params = {
+    name: subSeriesBag.subscriptionId,
+    path: subSeriesBag.subscriptionId,
+    visibility_level: subSeriesBag.gitlabAdapter.visibilityLevels.PRIVATE
+  };
+  /* jshint camelcase:true */
+
+  subSeriesBag.gitlabAdapter.postGroup(params,
+    function (err, group) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'postGroup returned error', err)
+        );
+      subSeriesBag.group = group;
+      subSeriesBag.groupExists = true;
+      return next();
+    }
+  );
+}
+
+function _grantPermission(subSeriesBag, next) {
+  var who = subSeriesBag.who + '|' + _grantPermission.name;
+  logger.debug(who, 'Inside');
+
+  /* jshint camelcase:false */
+  var params = {
+    id: subSeriesBag.group.id,
+    user_id: subSeriesBag.user.id,
+    access_level: subSeriesBag.gitlabAdapter.groupAccessLevels.OWNER
+  };
+  /* jshint camelcase:true */
+
+  subSeriesBag.gitlabAdapter.postAddMember(subSeriesBag.group.id, params,
+    function (err) {
+      if (err && err !== 409)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'postAddMember returned error', err)
+        );
+      return next();
+    }
+  );
+}

--- a/api/state/gitlab/pushRepo.sh
+++ b/api/state/gitlab/pushRepo.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -e
+
+export PRIVATE_KEY="<%=privateKey%>"
+export PROJECT_CLONE_LOCATION="<%=cloneLocation%>"
+export PEM_FILE_PATH="<%=pemFilePath%>"
+export SHA_FILE_PATH="<%=shaFilePath%>"
+export SUBSCRIPTION_EMAIL="<%=subscriptionEmail%>"
+export SUBSCRIPTION_NAME="<%=subscriptionName%>"
+export COMMIT_MESSAGE="<%=commitMessage%>"
+
+git_sync() {
+  echo "----> Pushing Directory $PROJECT_CLONE_LOCATION"
+  pushd $PROJECT_CLONE_LOCATION
+
+  echo "----> Adding Git Config"
+  git config --global user.email "$SUBSCRIPTION_EMAIL"
+  git config --global user.name "$SUBSCRIPTION_NAME"
+
+  echo "----> Adding Git Files"
+  git add .
+
+  if [ ! -z "$(git status --porcelain)" ]; then
+    echo "----> Committing Git Message"
+    git commit -m "$COMMIT_MESSAGE"
+
+    echo "----> Pushing to GitLab"
+    ssh-agent bash -c 'ssh-add $PEM_FILE_PATH; git push origin master'
+  else
+    echo "----> Nothing to Push"
+  fi
+
+  echo "----> Saving Resource SHA"
+  {
+    echo $SHA_FILE_PATH
+    git rev-parse HEAD > $SHA_FILE_PATH
+  } || {
+    echo "----> Empty repo, skipping version update"
+  }
+
+  echo "----> Popping $PROJECT_CLONE_LOCATION"
+  popd
+}
+
+main() {
+  echo '----> Executing git_sync'
+  git_sync
+}
+
+main

--- a/api/state/migrateNoneToGitLab.js
+++ b/api/state/migrateNoneToGitLab.js
@@ -1,0 +1,160 @@
+'use strict';
+
+var self = migrateNoneToGitLab;
+module.exports = self;
+
+var async = require('async');
+var _ = require('underscore');
+
+var GitLabAdapter = require('../../common/GitLabAdapter.js');
+
+function migrateNoneToGitLab(previousIntegration, gitlabIntegration, resource,
+  isStateResource, versions, apiAdapter, callback) {
+  var bag = {
+    resourceId: resource.id,
+    resourceName: resource.name,
+    subscriptionId: resource.subscriptionId,
+    gitlabIntegration: gitlabIntegration
+  };
+
+  bag.who = util.format('state|%s|id:%s', self.name, bag.resourceId);
+  logger.verbose(bag.who, 'Starting');
+
+  async.series([
+      _checkInputParams.bind(null, bag),
+      _getSubscriptionById.bind(null, bag),
+      _createGitLabAdapter.bind(null, bag),
+      _getNamespaceId.bind(null, bag),
+      _createProject.bind(null, bag)
+    ],
+    function (err) {
+      logger.verbose(bag.who, 'Completed');
+      if (err)
+        logger.error(err);
+
+      return callback(err);
+    }
+  );
+}
+
+function _checkInputParams(bag, next) {
+  var who = bag.who + '|' + _checkInputParams.name;
+  logger.debug(who, 'Inside');
+
+  if (!bag.resourceName)
+    return next(
+      new ActErr(who, ActErr.InvalidParam,
+        'parameter not found :resourceName')
+    );
+
+  if (!bag.gitlabIntegration)
+    return next(
+      new ActErr(who, ActErr.InvalidParam,
+        'parameter not found :gitlabIntegration')
+    );
+
+  return next();
+}
+
+function _getSubscriptionById(bag, next) {
+  var who = bag.who + '|' + _getSubscriptionById.name;
+  logger.debug(who, 'Inside');
+
+  var query = util.format(
+    'SELECT "propertyBag" FROM subscriptions WHERE id=\'%s\'',
+    bag.subscriptionId);
+  global.config.client.query(query,
+    function (err, res) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'Failed to find subscription ' + bag.subscriptionId +
+            ' with error: ' + util.inspect(err))
+        );
+
+      if (!res.rows[0])
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'No subscription found for id ' + bag.subscriptionId)
+        );
+
+      var propertyBag = JSON.parse(res.rows[0].propertyBag);
+
+      bag.username = propertyBag.nodeUserName;
+      bag.password = propertyBag.nodePassword;
+      return next();
+    }
+  );
+}
+
+function _createGitLabAdapter(bag, next) {
+  var who = bag.who + '|' + _createGitLabAdapter.name;
+  logger.debug(who, 'Inside');
+
+  bag.gitlabAdapter = new GitLabAdapter(null,
+    bag.gitlabIntegration.data.url, bag.username, bag.password);
+  bag.gitlabAdapter.initialize(
+    function (err, body) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'initialize returned error ' + err + ' with body ' + body)
+        );
+
+      return next();
+    }
+  );
+}
+
+function _getNamespaceId(bag, next) {
+  var who = bag.who + '|' + _getNamespaceId.name;
+  logger.debug(who, 'Inside');
+
+  bag.gitlabAdapter.getNamespaces(
+    function (err, namespaces) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'getNamespaces returned error', err)
+        );
+
+      if (_.isEmpty(namespaces))
+        return next(
+          new ActErr(who, ActErr.DataNotFound,
+            'getNamespaces returned no namespaces')
+        );
+
+      var namespace = _.findWhere(namespaces, {kind: 'group'});
+
+      if (!namespace)
+        return next(
+          new ActErr(who, ActErr.DataNotFound,
+            'getNamespaces returned no namespace of kind group for ' +
+              'subscriptionId: ' + bag.subscriptionId)
+        );
+
+      bag.projectNamespaceId = namespace.id;
+      return next();
+    }
+  );
+}
+
+function _createProject(bag, next) {
+  var who = bag.who + '|' + _createProject.name;
+  logger.debug(who, 'Inside');
+
+  var path = bag.resourceName.toLowerCase();
+  bag.gitlabAdapter.postProject(bag.resourceName, path,
+    bag.gitlabAdapter.visibilityLevels.PRIVATE, bag.projectNamespaceId,
+    function (err, body) {
+      if (err)
+        return next(
+          new ActErr(who, ActErr.OperationFailed,
+            'postProject returned error with status code ' + err +
+            'with body ' + util.inspect(body))
+        );
+
+      return next();
+    }
+  );
+}

--- a/api/state/post.js
+++ b/api/state/post.js
@@ -103,21 +103,11 @@ function _post(bag, next) {
   if (_.has(bag.reqBody, 'isShippableManaged'))
     bag.config.isShippableManaged = bag.reqBody.isShippableManaged;
 
-  if (_.has(bag.reqBody, 'type')) {
-    if (bag.config.type === bag.reqBody.type)
-      bag.config.type = bag.reqBody.type;
-    else if (bag.config.type === 'none' || (bag.config.type === 'gitlabCreds' &&
-      bag.reqBody.type === 'amazonKeys')) {
-      bag.config.type = bag.reqBody.type;
-      bag.config.isInstalled = false;
-      bag.config.isInitialized = false;
-    } else if (bag.config.isInstalled || bag.config.isInitialized)
-      return next(
-        new ActErr(who, ActErr.InvalidParam,
-          'Cannnot change type of initialized state')
-      );
-    else
-      bag.config.type = bag.reqBody.type;
+  if (_.has(bag.reqBody, 'type') &&
+    bag.config.type !== bag.reqBody.type) {
+    bag.config.type = bag.reqBody.type;
+    bag.config.isInstalled = false;
+    bag.config.isInitialized = false;
   }
 
   configHandler.put(bag.component, bag.config,

--- a/common/awsAdapter.js
+++ b/common/awsAdapter.js
@@ -146,6 +146,24 @@ S3.createBucket =
     );
   };
 
+S3.generateGETUrl =
+  function (bucket, key, expiration, callback) {
+    var params = {
+      Bucket: bucket,
+      Key: key,
+      Expires: expiration
+    };
+
+    this.s3.getSignedUrl('getObject', params,
+      function (err, data) {
+        if (err)
+          return callback(err);
+
+        return callback(null, data);
+      }
+    );
+  };
+
 S3.generatePUTUrl =
   function (bucket, key, expiration, additionalParams, callback) {
     var params = {

--- a/common/scripts/x86_64/Ubuntu_14.04/startFakeAPI.sh
+++ b/common/scripts/x86_64/Ubuntu_14.04/startFakeAPI.sh
@@ -112,7 +112,7 @@ __check_api() {
       grep $FAKE_API_CONTAINER_NAME | awk '{print $1}')
 
     if [ "$running_api_container" != "" ]; then
-      __process_msg "Waiting thrity seconds before stopping API container"
+      __process_msg "Waiting thirty seconds before stopping API container"
       is_booted=true
       sleep 30
 

--- a/common/scripts/x86_64/Ubuntu_16.04/startFakeAPI.sh
+++ b/common/scripts/x86_64/Ubuntu_16.04/startFakeAPI.sh
@@ -103,7 +103,7 @@ __check_api() {
       grep $FAKE_API_CONTAINER_NAME | awk '{print $1}')
 
     if [ "$running_api_container" != "" ]; then
-      __process_msg "Waiting thrity seconds before stopping API container"
+      __process_msg "Waiting thirty seconds before stopping API container"
       is_booted=true
       sleep 30
 


### PR DESCRIPTION
#2527 

Adds migrations to GitLab.  Migrating from no state storage just requires the subscription users and projects to be created.  Migrating from S3 also copies the files.

This also fixes an error where the wrong SSH port is selected for GitLab when switching from another state option and GitLab is on the same node as Admiral.