### PR TITLE
#2527; pages versions in state migration.

### DIFF
--- a/api/state/migrateNoneToGitLab.js
+++ b/api/state/migrateNoneToGitLab.js
@@ -9,7 +9,7 @@ var _ = require('underscore');
 var GitLabAdapter = require('../../common/GitLabAdapter.js');
 
 function migrateNoneToGitLab(previousIntegration, gitlabIntegration, resource,
-  isStateResource, versions, apiAdapter, callback) {
+  isStateResource, apiAdapter, callback) {
   var bag = {
     resourceId: resource.id,
     resourceName: resource.name,


### PR DESCRIPTION
#2527 

Gets the versions in each migration script instead of `migrate.js` so that we won't need to have all of the versions at the same time.