### PR TITLE
route roles for POST /passthrough/contactSUpport

### DIFF
--- a/migrations/migrations.sql
+++ b/migrations/migrations.sql
@@ -2327,13 +2327,6 @@ do $$
       roleCode := 6060
     );
 
-    -- Allow admins of subscriptions to access the route.
-    perform set_route_role(
-      routePattern := '/passthrough/contactSupport',
-      httpVerb := 'POST',
-      roleCode := 6020
-    );
-
     -- Allow justUser to access the route.
     perform set_route_role(
       routePattern := '/passthrough/contactSupport',


### PR DESCRIPTION
https://github.com/Shippable/api/issues/19667

Any user can access the route `POST /passthrough/contactSupport` 