### PR TITLE
adds public and private keys fields for gerritBasic masterIntegration

### DIFF
--- a/common/scripts/configs/master_integration_fields.sql
+++ b/common/scripts/configs/master_integration_fields.sql
@@ -405,6 +405,16 @@ do $$
       values (301, '577de63321333398d11a1122', 'url', 'string', true, false,'54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2018-08-06', '2018-08-06');
     end if;
 
+    if not exists (select 1 from "masterIntegrationFields" where "id" = 302) then
+      insert into "masterIntegrationFields" ("id", "masterIntegrationId", "name", "dataType", "isRequired", "isSecure","createdBy", "updatedBy", "createdAt", "updatedAt")
+      values (302, '577de63321333398d11a1122', 'publicKey', 'string', false, false,'54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2018-08-06', '2018-08-06');
+    end if;
+
+    if not exists (select 1 from "masterIntegrationFields" where "id" = 303) then
+      insert into "masterIntegrationFields" ("id", "masterIntegrationId", "name", "dataType", "isRequired", "isSecure","createdBy", "updatedBy", "createdAt", "updatedAt")
+      values (303, '577de63321333398d11a1122', 'privateKey', 'string', false, true,'54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2018-08-06', '2018-08-06');
+    end if;
+
     -- masterIntegrationFields for githubEnterpriseKeys
     if not exists (select 1 from "masterIntegrationFields" where "id" = 187) then
       insert into "masterIntegrationFields" ("id", "masterIntegrationId", "name", "dataType", "isRequired", "isSecure","createdBy", "updatedBy", "createdAt", "updatedAt")


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/2607

```
shipdb=# select * from "masterIntegrationFields" where "id"=302;
-[ RECORD 1 ]-------+-------------------------
id                  | 302
masterIntegrationId | 577de63321333398d11a1122
name                | publicKey
dataType            | string
isRequired          | f
isSecure            | f
createdBy           | 54188262bc4d591ba438d62a
updatedBy           | 54188262bc4d591ba438d62a
createdAt           | 2018-08-06 00:00:00+00
updatedAt           | 2018-08-06 00:00:00+00

shipdb=# select * from "masterIntegrationFields" where "id"=303;
-[ RECORD 1 ]-------+-------------------------
id                  | 303
masterIntegrationId | 577de63321333398d11a1122
name                | privateKey
dataType            | string
isRequired          | f
isSecure            | t
createdBy           | 54188262bc4d591ba438d62a
updatedBy           | 54188262bc4d591ba438d62a
createdAt           | 2018-08-06 00:00:00+00
updatedAt           | 2018-08-06 00:00:00+00

```