### PR TITLE
upgrading docker on workers 

### DIFF
--- a/common/scripts/upgrade.sh
+++ b/common/scripts/upgrade.sh
@@ -4,6 +4,13 @@ readonly MAX_ERROR_LOG_COUNT=100
 export IS_SERVER=false
 export system_cluster=null
 
+__update_docker() {
+  __process_msg "Updating docker"
+  ##if [ "$INSTALLED_DOCKER_VERSION" != "$DOCKER_VERSION" ]; then
+  source $SCRIPTS_DIR/upgrade_docker.sh
+  __process_msg "DONE"
+}
+
 __check_admiral() {
   __process_msg "Checking if admiral container is running"
   local wait_time=3
@@ -456,9 +463,7 @@ main() {
     __process_marker "Upgrading Shippable installation"
     __pull_images_master
     __pull_images_workers
-    if [ "$INSTALLED_DOCKER_VERSION" != "$DOCKER_VERSION" ]; then
-      source $SCRIPTS_DIR/upgrade_docker.sh
-    fi
+    __update_docker
     __check_admiral
     __check_release
     __update_release

--- a/common/scripts/upgrade_docker.sh
+++ b/common/scripts/upgrade_docker.sh
@@ -42,8 +42,10 @@ __remove_services() {
   fi
 }
 
-__upgrade_docker_version_on_swarm_workers() {
+__update_docker_on_swarm_workers() {
   __process_msg "Upgrading docker version on swarm workers"
+  ## Note: this always needs to execute since it'll update proxy settings on
+  ## swarm worker nodes
 
   local system_settings="PGPASSWORD=$DB_PASSWORD \
     psql \
@@ -112,7 +114,10 @@ __upgrade_docker_version_on_swarm_workers() {
   done
 }
 
-__upgrade_docker_version() {
+__update_docker() {
+  ## Note: this always needs to execute since it'll update proxy settings on
+  ## swarm master
+
   __process_msg "Upgrading docker to $DOCKER_VERSION"
   __create_install_docker_script
   ./$INSTALL_DOCKER_SCRIPT
@@ -153,8 +158,8 @@ main() {
   __process_marker "Upgrading docker"
 
   __remove_services
-  __upgrade_docker_version
-  __upgrade_docker_version_on_swarm_workers
+  __update_docker
+  __update_docker_on_swarm_workers
   __upgrade_awscli_version
   __set_installed_docker_version
   __restart_db_container

--- a/common/scripts/upgrade_docker.sh
+++ b/common/scripts/upgrade_docker.sh
@@ -1,19 +1,36 @@
 #!/bin/bash -e
 
-export DOCKER_UPGRADE_REQUIRED=true
 export INSTALL_DOCKER_SCRIPT="installDockerScript.sh"
 
-__check_upgrade_required() {
-  __process_msg "Checking if docker upgrade is required"
 
-  local smaller_version=$(printf "$INSTALLED_DOCKER_VERSION\n$DOCKER_VERSION" | sort | head -n 1)
-  if [ "$smaller_version" != "$INSTALLED_DOCKER_VERSION" ]; then
-    __process_msg "Docker upgrade not required"
-    DOCKER_UPGRADE_REQUIRED=false
-  else
-    __process_msg "Docker upgrade required"
-    __create_install_docker_script
-  fi
+__create_install_docker_script() {
+  __process_msg "Creating docker install script"
+
+  rm -f $INSTALL_DOCKER_SCRIPT
+  touch $INSTALL_DOCKER_SCRIPT
+  echo '#!/bin/bash' >> $INSTALL_DOCKER_SCRIPT
+  echo 'install_docker_only="true"' >> $INSTALL_DOCKER_SCRIPT
+  echo "SHIPPABLE_HTTP_PROXY=\"$SHIPPABLE_HTTP_PROXY\"" >> installDockerScript.sh
+  echo "SHIPPABLE_HTTPS_PROXY=\"$SHIPPABLE_HTTPS_PROXY\"" >> installDockerScript.sh
+  echo "SHIPPABLE_NO_PROXY=\"$SHIPPABLE_NO_PROXY\"" >> installDockerScript.sh
+
+  local node_scripts_location=/tmp/node
+  local node_s3_location="https://s3.amazonaws.com/shippable-artifacts/node/$RELEASE/node-$RELEASE.tar.gz"
+
+  pushd /tmp
+  mkdir -p $node_scripts_location
+  wget $node_s3_location
+  tar -xzf node-$RELEASE.tar.gz -C $node_scripts_location --strip-components=1
+  rm -rf node-$RELEASE.tar.gz
+  popd
+
+  cat $node_scripts_location/lib/logger.sh >> $INSTALL_DOCKER_SCRIPT
+  cat $node_scripts_location/lib/headers.sh >> $INSTALL_DOCKER_SCRIPT
+  cat $node_scripts_location/initScripts/$ARCHITECTURE/$OPERATING_SYSTEM/Docker_"$DOCKER_VERSION".sh >> $INSTALL_DOCKER_SCRIPT
+
+  rm -rf $node_scripts_location
+  # Install Docker
+  chmod +x $INSTALL_DOCKER_SCRIPT
 }
 
 __remove_services() {
@@ -25,158 +42,116 @@ __remove_services() {
   fi
 }
 
-__create_install_docker_script() {
-  if $DOCKER_UPGRADE_REQUIRED; then
-    __process_msg "Creating docker install script"
-
-    rm -f $INSTALL_DOCKER_SCRIPT
-    touch $INSTALL_DOCKER_SCRIPT
-    echo '#!/bin/bash' >> $INSTALL_DOCKER_SCRIPT
-    echo 'install_docker_only="true"' >> $INSTALL_DOCKER_SCRIPT
-    echo "SHIPPABLE_HTTP_PROXY=\"$SHIPPABLE_HTTP_PROXY\"" >> installDockerScript.sh
-    echo "SHIPPABLE_HTTPS_PROXY=\"$SHIPPABLE_HTTPS_PROXY\"" >> installDockerScript.sh
-    echo "SHIPPABLE_NO_PROXY=\"$SHIPPABLE_NO_PROXY\"" >> installDockerScript.sh
-
-    local node_scripts_location=/tmp/node
-    local node_s3_location="https://s3.amazonaws.com/shippable-artifacts/node/$RELEASE/node-$RELEASE.tar.gz"
-
-    pushd /tmp
-    mkdir -p $node_scripts_location
-    wget $node_s3_location
-    tar -xzf node-$RELEASE.tar.gz -C $node_scripts_location --strip-components=1
-    rm -rf node-$RELEASE.tar.gz
-    popd
-
-    cat $node_scripts_location/lib/logger.sh >> $INSTALL_DOCKER_SCRIPT
-    cat $node_scripts_location/lib/headers.sh >> $INSTALL_DOCKER_SCRIPT
-    cat $node_scripts_location/initScripts/$ARCHITECTURE/$OPERATING_SYSTEM/Docker_"$DOCKER_VERSION".sh >> $INSTALL_DOCKER_SCRIPT
-
-    rm -rf $node_scripts_location
-    # Install Docker
-    chmod +x $INSTALL_DOCKER_SCRIPT
-  fi
-}
-
 __upgrade_docker_version_on_swarm_workers() {
-  if $DOCKER_UPGRADE_REQUIRED; then
-    __process_msg "Upgrading docker version on swarm workers"
+  __process_msg "Upgrading docker version on swarm workers"
 
-    local system_settings="PGPASSWORD=$DB_PASSWORD \
-      psql \
-      -U $DB_USER \
-      -d $DB_NAME \
-      -h $DB_IP \
-      -p $DB_PORT \
-      -v ON_ERROR_STOP=1 \
-      -tc 'SELECT workers from \"systemSettings\"; '"
+  local system_settings="PGPASSWORD=$DB_PASSWORD \
+    psql \
+    -U $DB_USER \
+    -d $DB_NAME \
+    -h $DB_IP \
+    -p $DB_PORT \
+    -v ON_ERROR_STOP=1 \
+    -tc 'SELECT workers from \"systemSettings\"; '"
 
-    {
-      system_settings=`eval $system_settings` &&
-      __process_msg "'systemSettings' table exists, finding workers"
-    } || {
-      __process_msg "'systemSettings' table does not exist, skipping"
-      return
-    }
+  {
+    system_settings=`eval $system_settings` &&
+    __process_msg "'systemSettings' table exists, finding workers"
+  } || {
+    __process_msg "'systemSettings' table does not exist, skipping"
+    return
+  }
 
-    local workers=$(echo $system_settings | jq '.')
-    local workers_count=$(echo $workers | jq '. | length')
+  local workers=$(echo $system_settings | jq '.')
+  local workers_count=$(echo $workers | jq '. | length')
 
-    local get_master_cmd="PGPASSWORD=$DB_PASSWORD \
-      psql \
-      -U $DB_USER \
-      -d $DB_NAME \
-      -h $DB_IP \
-      -p $DB_PORT \
-      -v ON_ERROR_STOP=1 \
-      -tc 'SELECT master from \"systemSettings\"; '"
-    local master=$(eval $get_master_cmd | jq '.');
-    local master_address=$(echo $master | jq '.address');
+  local get_master_cmd="PGPASSWORD=$DB_PASSWORD \
+    psql \
+    -U $DB_USER \
+    -d $DB_NAME \
+    -h $DB_IP \
+    -p $DB_PORT \
+    -v ON_ERROR_STOP=1 \
+    -tc 'SELECT master from \"systemSettings\"; '"
+  local master=$(eval $get_master_cmd | jq '.');
+  local master_address=$(echo $master | jq '.address');
 
-    __process_msg "Found $workers_count workers"
-    for i in $(seq 1 $workers_count); do
-      local worker=$(echo $workers | jq '.['"$i-1"']')
-      local host=$(echo $worker | jq -r '.address')
-      local port=$(echo $worker | jq -r '.port')
-      local is_initialized=$(echo $worker | jq -r '.isInitialized')
-      if [ $is_initialized == false ]; then
-        __process_msg "worker $host not initialized, skipping"
-        continue
-      fi
+  __process_msg "Found $workers_count workers"
+  for i in $(seq 1 $workers_count); do
+    local worker=$(echo $workers | jq '.['"$i-1"']')
+    local host=$(echo $worker | jq -r '.address')
+    local port=$(echo $worker | jq -r '.port')
+    local is_initialized=$(echo $worker | jq -r '.isInitialized')
+    if [ $is_initialized == false ]; then
+      __process_msg "worker $host not initialized, skipping"
+      continue
+    fi
 
-      if [ $host == $ADMIRAL_IP ]; then
-        continue
-      fi
+    if [ $host == $ADMIRAL_IP ]; then
+      continue
+    fi
 
-      local script_name="installWorker.sh"
-      local install_worker_script="$SCRIPTS_DIR/$ARCHITECTURE/$OPERATING_SYSTEM/remote/$script_name"
-      local worker_install_cmd="WORKER_HOST=$host \
-        WORKER_JOIN_TOKEN=$SWARM_WORKER_JOIN_TOKEN \
-        WORKER_PORT=$port \
-        MASTER_HOST=$master_address \
-        RELEASE=$RELEASE \
-        NO_VERIFY_SSL=$NO_VERIFY_SSL \
-        ARCHITECTURE=$ARCHITECTURE \
-        OPERATING_SYSTEM=$OPERATING_SYSTEM \
-        INSTALLED_DOCKER_VERSION=$DOCKER_VERSION \
-        SHIPPABLE_HTTP_PROXY=$SHIPPABLE_HTTP_PROXY \
-        SHIPPABLE_HTTPS_PROXY=$SHIPPABLE_HTTPS_PROXY \
-        SHIPPABLE_NO_PROXY=$SHIPPABLE_NO_PROXY \
-        $SCRIPTS_DIR_REMOTE/$script_name"
+    local script_name="installWorker.sh"
+    local install_worker_script="$SCRIPTS_DIR/$ARCHITECTURE/$OPERATING_SYSTEM/remote/$script_name"
+    local worker_install_cmd="WORKER_HOST=$host \
+      WORKER_JOIN_TOKEN=$SWARM_WORKER_JOIN_TOKEN \
+      WORKER_PORT=$port \
+      MASTER_HOST=$master_address \
+      RELEASE=$RELEASE \
+      NO_VERIFY_SSL=$NO_VERIFY_SSL \
+      ARCHITECTURE=$ARCHITECTURE \
+      OPERATING_SYSTEM=$OPERATING_SYSTEM \
+      INSTALLED_DOCKER_VERSION=$DOCKER_VERSION \
+      SHIPPABLE_HTTP_PROXY=$SHIPPABLE_HTTP_PROXY \
+      SHIPPABLE_HTTPS_PROXY=$SHIPPABLE_HTTPS_PROXY \
+      SHIPPABLE_NO_PROXY=$SHIPPABLE_NO_PROXY \
+      $SCRIPTS_DIR_REMOTE/$script_name"
 
-      __copy_script_remote "$host" "$install_worker_script" "$SCRIPTS_DIR_REMOTE"
-      __exec_cmd_remote "$host" "$worker_install_cmd"
-    done
-  fi
+    __copy_script_remote "$host" "$install_worker_script" "$SCRIPTS_DIR_REMOTE"
+    __exec_cmd_remote "$host" "$worker_install_cmd"
+  done
 }
 
 __upgrade_docker_version() {
-  if $DOCKER_UPGRADE_REQUIRED; then
-    __process_msg "Upgrading docker to $DOCKER_VERSION"
-
-    ./$INSTALL_DOCKER_SCRIPT
-    rm -f $INSTALL_DOCKER_SCRIPT
-  fi
+  __process_msg "Upgrading docker to $DOCKER_VERSION"
+  __create_install_docker_script
+  ./$INSTALL_DOCKER_SCRIPT
+  rm -f $INSTALL_DOCKER_SCRIPT
 }
 
 __upgrade_awscli_version() {
+  __process_msg "Upgrading AWS cli to : $AWSCLI_VERSION"
   pip install awscli==$AWSCLI_VERSION
 }
 
 __restart_db_container() {
-  if $DOCKER_UPGRADE_REQUIRED; then
-    local db_container_name="db"
-    local db_container=$(sudo docker ps -a --format "{{.Names}}" | grep -w "db") || true
-    if [ ! -z "$db_container" ]; then
-      __process_msg "Found a stopped $db_container_name container, starting it"
-      sudo docker start "$db_container_name"
-      sleep 3
-    else
-      __process_msg "DB not running as a container"
-    fi
+  local db_container_name="db"
+  local db_container=$(sudo docker ps -a --format "{{.Names}}" | grep -w "db") || true
+  if [ ! -z "$db_container" ]; then
+    __process_msg "Found a stopped $db_container_name container, starting it"
+    sudo docker start "$db_container_name"
+    sleep 3
+  else
+    __process_msg "DB not running as a container"
   fi
 }
 
 __restart_admiral() {
-  if $DOCKER_UPGRADE_REQUIRED; then
-    __process_msg "Booting admiral container"
-    source $SCRIPTS_DIR/$ARCHITECTURE/$OPERATING_SYSTEM/boot_admiral.sh
-    sleep 5
-  fi
+  __process_msg "Booting admiral container"
+  source $SCRIPTS_DIR/$ARCHITECTURE/$OPERATING_SYSTEM/boot_admiral.sh
+  sleep 5
 }
 
 __restart() {
-  if $DOCKER_UPGRADE_REQUIRED; then
-    IS_RESTART=true
-    export skip_starting_services=true
-    source $SCRIPTS_DIR/restart.sh
-    IS_RESTART=false
-  fi
+  IS_RESTART=true
+  export skip_starting_services=true
+  source $SCRIPTS_DIR/restart.sh
+  IS_RESTART=false
 }
 
 main() {
   __process_marker "Upgrading docker"
 
-  __check_upgrade_required
   __remove_services
   __upgrade_docker_version
   __upgrade_docker_version_on_swarm_workers

--- a/common/scripts/x86_64/Ubuntu_16.04/_helpers.sh
+++ b/common/scripts/x86_64/Ubuntu_16.04/_helpers.sh
@@ -78,37 +78,48 @@ __check_dependencies() {
   sudo chown -R shippable:shippable /home/shippable/
 
   ################## Install Docker  #####################################
-  __process_msg "Installing Docker $DOCKER_VERSION"
-  rm -f installDockerScript.sh
-  touch installDockerScript.sh
-  echo '#!/bin/bash' >> installDockerScript.sh
-  echo 'install_docker_only="true"' >> installDockerScript.sh
-  echo "SHIPPABLE_HTTP_PROXY=\"$SHIPPABLE_HTTP_PROXY\"" >> installDockerScript.sh
-  echo "SHIPPABLE_HTTPS_PROXY=\"$SHIPPABLE_HTTPS_PROXY\"" >> installDockerScript.sh
-  echo "SHIPPABLE_NO_PROXY=\"$SHIPPABLE_NO_PROXY\"" >> installDockerScript.sh
+  {
+    check_docker=$(sudo service --status-all 2>&1 | grep docker)
+  } || {
+    true
+  }
 
-  local node_scripts_location=/tmp/node
-  local node_s3_location="https://s3.amazonaws.com/shippable-artifacts/node/$RELEASE/node-$RELEASE.tar.gz"
-  pushd /tmp
-  mkdir -p $node_scripts_location
-  wget $node_s3_location
-  tar -xzf node-$RELEASE.tar.gz -C $node_scripts_location --strip-components=1
-  rm -rf node-$RELEASE.tar.gz
-  popd
+  if [ ! -z "$check_docker" ]; then
+    __process_msg "'docker' already installed, skipping"
+  else
+    __process_msg "Installing Docker $DOCKER_VERSION"
 
-  cat $node_scripts_location/lib/logger.sh >> installDockerScript.sh
-  cat $node_scripts_location/lib/headers.sh >> installDockerScript.sh
-  cat $node_scripts_location/initScripts/$ARCHITECTURE/$OPERATING_SYSTEM/Docker_$DOCKER_VERSION.sh >> installDockerScript.sh
+    rm -f installDockerScript.sh
+    touch installDockerScript.sh
+    echo '#!/bin/bash' >> installDockerScript.sh
+    echo 'install_docker_only="true"' >> installDockerScript.sh
+    echo "SHIPPABLE_HTTP_PROXY=\"$SHIPPABLE_HTTP_PROXY\"" >> installDockerScript.sh
+    echo "SHIPPABLE_HTTPS_PROXY=\"$SHIPPABLE_HTTPS_PROXY\"" >> installDockerScript.sh
+    echo "SHIPPABLE_NO_PROXY=\"$SHIPPABLE_NO_PROXY\"" >> installDockerScript.sh
 
-  rm -rf $node_scripts_location
-  # Install Docker
-  chmod +x installDockerScript.sh
-  ./installDockerScript.sh
+    local node_scripts_location=/tmp/node
+    local node_s3_location="https://s3.amazonaws.com/shippable-artifacts/node/$RELEASE/node-$RELEASE.tar.gz"
+    pushd /tmp
+    mkdir -p $node_scripts_location
+    wget $node_s3_location
+    tar -xzf node-$RELEASE.tar.gz -C $node_scripts_location --strip-components=1
+    rm -rf node-$RELEASE.tar.gz
+    popd
 
-  # sets env INSTALLED_DOCKER_VERSION
-  __set_installed_docker_version
+    cat $node_scripts_location/lib/logger.sh >> installDockerScript.sh
+    cat $node_scripts_location/lib/headers.sh >> installDockerScript.sh
+    cat $node_scripts_location/initScripts/$ARCHITECTURE/$OPERATING_SYSTEM/Docker_$DOCKER_VERSION.sh >> installDockerScript.sh
 
-  rm installDockerScript.sh
+    rm -rf $node_scripts_location
+    # Install Docker
+    chmod +x installDockerScript.sh
+    ./installDockerScript.sh
+
+    # sets env INSTALLED_DOCKER_VERSION
+    __set_installed_docker_version
+
+    rm installDockerScript.sh
+  fi
 
   ################## Install awscli  #####################################
   if type aws &> /dev/null && true; then


### PR DESCRIPTION
- https://github.com/Shippable/pm/issues/11277
- docker on workers was not getting upgraded with the `./admiral.sh upgrade` command. this PR fixes the workflow
- this also refactors the workflow to install docker
    - the __check_dependencies() function will now **only** install docker if its not already present. Earlier this was installing docker unconditionally 
    - upgrade workflow will always run the install_docker scripts. this will make sure that proxy envs are correctly set. this was earlier taken care of by the __check_dependencies() function
- scenarios tested
    - fresh onebox install
    - multibox install
    - upgrade on onebox from old docker to new docker
    - upgrade on multi-box from old docker to new docker