### PR TITLE
Add shipctl notify to release notes.

### DIFF
--- a/releaseNotes/master.md
+++ b/releaseNotes/master.md
@@ -6,6 +6,7 @@ ${REL_VER_DATE}
 ## Features
   - **More node statistics**: Node statistics are collected more frequently and the number of Docker containers and images on a node is now displayed on the node page.  Existing nodes will need to be reinitialized in order to show the image count, but reinitialization is not required to continue to use older nodes.
   - **Ability to re-initialize the node in nodepool list page**: Nodes can now be re-initialized from the node pool page instead of having to go to the node's detail page.
+  - **shipctl notify**: Custom notifications can be sent to Slack or webhooks using `shipctl`. Custom nodes will need to be reinitialized to use this feature and Windows is not yet supported. More information is available in the [shipctl documentation](http://docs.shippable.com/platform/tutorial/workflow/using-shipctl/).
 
 ## Fixes
   - **Cleanup credentials before and after the CI build**: Credentials used in the CI builds will get cleaned up from the build agent before and after the CI build is run.


### PR DESCRIPTION
Shippable/heap#2518

The `shipctl notify` command will be available for Slack and webhooks on Ubuntu, CentOS, RHEL, and MacOS, but not yet IRC or Windows.