### PR TITLE
Shippable/heap#2502 release notes.

### DIFF
--- a/releaseNotes/master.md
+++ b/releaseNotes/master.md
@@ -4,11 +4,7 @@
 ${REL_VER_DATE}
 
 ## Features
-  - **simple title**: brief description. [link to docs](#).
-      - itemized
-      - list
-      - for details
-      - if necessary
+  - **Excluded branches can be run manually**: CI branches that do not run for webhooks because of a `branches` setting in `shippable.yml` can now be run manually. To do so, click the play button on the project dashboard and select the branch.
 
 ## Fixes
   - **simple title**: brief description


### PR DESCRIPTION
Shippable/heap#2502

The `branches` settings now only apply to webhooks; an excluded branch can be run manually.