### PR TITLE
Adds job input to jobs without state to release notes.

### DIFF
--- a/releaseNotes/master.md
+++ b/releaseNotes/master.md
@@ -26,6 +26,8 @@ ${REL_VER_DATE}
 
 ## Shippable Server
 
+- **Using runSh inputs without state storage**: A `runSh` job can now be used as an input to another `runSh` or CI job in installations without state storage.
+
 ### Features
 
 - **simple title**: brief description


### PR DESCRIPTION
Shippable/heap#2552

Job inputs to jobs without state will no longer fail because of the missing state information.