### PR TITLE
Adds heap#2599 to release notes.

### DIFF
--- a/releaseNotes/master.md
+++ b/releaseNotes/master.md
@@ -6,7 +6,8 @@ ${REL_VER_DATE}
 
 ## Features
 
-- **Added Subscripton State panel on subscription dashboard**: The parallel job count and private job limit for a subscripton is now visible under the breadcrumb on the subscription dashboard.
+- **Added Subscription State panel on subscription dashboard**: The parallel job count and private job limit for a subscription is now visible under the breadcrumb on the subscription dashboard.
+- **Amazon ECS Daemon Deployments**: Managed deploy jobs can now deploy daemon services to Amazon ECS by setting `schedulingStrategy` to `DAEMON` in a  `dockerOptions` input.
 
 ## Fixes
 


### PR DESCRIPTION
Shippable/heap#2599

Amazon ECS `schedulingStrategy` `DAEMON` is now allowed.