### PR TITLE
adds release notes for core shippable service to use internal API

### DIFF
--- a/releaseNotes/master.md
+++ b/releaseNotes/master.md
@@ -32,7 +32,7 @@ ${REL_VER_DATE}
 
 ### Fixes
 
-- **simple title**: brief description
+- **Core Shippable services use internal API**: Previously some of the core services were connected to the console API. This has been fixed to use the internal API.
 
 ## History
 

--- a/releaseNotes/master.md
+++ b/releaseNotes/master.md
@@ -32,7 +32,7 @@ ${REL_VER_DATE}
 
 ### Fixes
 
-- **Core Shippable services use internal API**: Previously some of the core services were connected to the console API. This has been fixed to use the internal API.
+- **Core Shippable services use internal API**: In installations that had configured Public, Internal and Console APIs, some of the core services were incorrectly connecting to the Console API. This has been fixed and all core services now connect to the Internal API when available.
 
 ## History
 


### PR DESCRIPTION
https://github.com/Shippable/heap/issues/2635