### PR TITLE
Adds Bitbucket API updates to release notes.

### DIFF
--- a/releaseNotes/master.md
+++ b/releaseNotes/master.md
@@ -7,6 +7,7 @@ ${REL_VER_DATE}
 ## Features
 
 - **Adhere to stricter validation requirements on GitHub api calls**: The GitHub API will apply [stricter validation rules from 1 Nov 2018](https://developer.github.com/changes/2018-09-25-stricter-validation-coming-soon-in-the-rest-api/). The payload of the "create webhook" API call that we make to GitHub when a CI project is enabled or gitRepo and syncRepo resources are added has been updated to comply with the new validation requirements. No changes were required on the other API calls that we make to GitHub.
+- **Bitbucket sync updates**: We've made some modifications to how we synchronize information from Bitbucket to prepare for the removal of version 1 of the Bitbucket Cloud REST API.  No noticeable changes are expected for Bitbucket users on Shippable.
 
 ## Fixes
 


### PR DESCRIPTION
Shippable/heap#2562

Adds a note that we've made some updates to how we synchronize information with Bitbucket.