### PR TITLE
Adds admin build analytics refresh release notes.

### DIFF
--- a/releaseNotes/master.md
+++ b/releaseNotes/master.md
@@ -28,7 +28,7 @@ ${REL_VER_DATE}
 
 ### Fixes
 
-- **simple title**: brief description
+- **Refreshing admin build analytics displayed additional dates**: The refresh button on the admin build analytics page functioned as both reset and load more. It will now only refresh.
 
 ## History
 


### PR DESCRIPTION
Shippable/heap#2656

Release notes for update to refresh button.  It will no longer both refresh and load more.  There is still a separate "load more" button.