### PR TITLE
Adds gitRepo webhook update to release notes.

### DIFF
--- a/releaseNotes/master.md
+++ b/releaseNotes/master.md
@@ -16,6 +16,7 @@ ${REL_VER_DATE}
 - **Fix docker version in Machine Images**: The docker version got incorrectly upgraded to 18.03 in all GCE [Machine Images](http://docs.shippable.com/platform/runtime/machine-image/ami-overview/). This has been fixed. Now, the Machine Images have the correct version of docker installed.
 - **Retry python setup_ve in runCI jobs**: Sometimes, the setup_ve section in python jobs fail due to network errors. We have added a shippable_retry for python's setup_ve section so that this section retries in case of errors.
 - **CI services stopped in `build_always`**: Stop commands were run for services in CI jobs in both `build_on_success` or `build_on_failure` and `build_always`. Those commands will now only run in `build_always`.
+- **gitRepo resources not updated by webhooks**: Some `gitRepo` resources with a `sourceName` that does not exactly match the repository name, for example a lowercase instead of capital letter, will now be updated for webhooks received from the source provider when the repository has been previously identified by `rSync`.
 
 ## Custom Nodes
 


### PR DESCRIPTION
Shippable/heap#2682

How new webhooks identify the resources to be updated has changed slightly to allow for variations in names allowed by the source providers.