### PR TITLE
Adds new subscription integration queries to release notes.

### DIFF
--- a/releaseNotes/master.md
+++ b/releaseNotes/master.md
@@ -8,6 +8,7 @@ ${REL_VER_DATE}
 
 - **Drydock update**: Updating all Shippable official images with latest stable versions of [languages](http://docs.shippable.com/platform/runtime/machine-image/language-versions/), [cli's](http://docs.shippable.com/platform/runtime/machine-image/cli-versions/) and [services](http://docs.shippable.com/platform/runtime/machine-image/services-versions/). Refer to documentation
   for [v6.11.4](http://docs.shippable.com/platform/runtime/machine-image/ami-v6114/) for details.
+- **Subscription Integrations API**: It is now possible to filter subscription integrations by master integration (name, type, or ID) through the Shippable API by including `masterIntegrationNames`, `masterIntegrationTypes`, or `masterIntegrationIds` query parameters.
 
 ## Fixes
 


### PR DESCRIPTION
Shippable/heap#2687

More query options (`masterIntegrationIds`, `masterIntegrationNames`, and `masterIntegrationTypes`) have been added to `GET /subscriptionIntegrations`.