### PR TITLE
update rabbitmq version

### DIFF
--- a/common/scripts/x86_64/CentOS_7/remote/installMsg.sh
+++ b/common/scripts/x86_64/CentOS_7/remote/installMsg.sh
@@ -17,8 +17,8 @@ install_rabbitmq() {
   yum install -y "erlang-19.3.6.4-1.el7.centos.x86_64.rpm"
   rm -f "erlang-19.3.6.4-1.el7.centos.x86_64.rpm"
 
-  local rabbitmq_version="3.6.5"
-  wget "https://bintray.com/rabbitmq/rabbitmq-server-rpm/download_file?file_path=rabbitmq-server-$rabbitmq_version-1.noarch.rpm" -O rabbitmq-server-$rabbitmq_version.rpm
+  local rabbitmq_version="3.6.16"
+  wget "https://bintray.com/rabbitmq/rabbitmq-server-rpm/download_file?file_path=rabbitmq-server-$rabbitmq_version-1.el7.noarch.rpm" -O rabbitmq-server-$rabbitmq_version.rpm
   yum install -y "rabbitmq-server-$rabbitmq_version.rpm"
   rm -f "rabbitmq-server-$rabbitmq_version.rpm"
 }

--- a/common/scripts/x86_64/RHEL_7/remote/installMsg.sh
+++ b/common/scripts/x86_64/RHEL_7/remote/installMsg.sh
@@ -18,8 +18,8 @@ install_rabbitmq() {
   rm -f "erlang-19.3.6.4-1.el7.centos.x86_64.rpm"
 
 
-  local rabbitmq_version="3.6.5"
-  wget "https://bintray.com/rabbitmq/rabbitmq-server-rpm/download_file?file_path=rabbitmq-server-$rabbitmq_version-1.noarch.rpm" -O rabbitmq-server-$rabbitmq_version.rpm
+  local rabbitmq_version="3.6.16"
+  wget "https://bintray.com/rabbitmq/rabbitmq-server-rpm/download_file?file_path=rabbitmq-server-$rabbitmq_version-1.el7.noarch.rpm" -O rabbitmq-server-$rabbitmq_version.rpm
   yum install -y "rabbitmq-server-$rabbitmq_version.rpm"
   rm -f "rabbitmq-server-$rabbitmq_version.rpm"
 }


### PR DESCRIPTION
c7, RHEL installs are failing since the old rabbitmq package is not maintained.

https://github.com/Shippable/pm/issues/11786