### PR TITLE
updates airBrakeKey level and displayName

### DIFF
--- a/common/scripts/configs/master_integrations.sql
+++ b/common/scripts/configs/master_integrations.sql
@@ -343,7 +343,7 @@ do $$
     -- airBrakeKey master integration
     if not exists (select 1 from "masterIntegrations" where "name" = 'airBrakeKey' and "typeCode" = 5012) then
       insert into "masterIntegrations" ("id", "masterIntegrationId", "name", "displayName", "type", "isEnabled", "level", "typeCode", "createdBy", "updatedBy", "createdAt", "updatedAt")
-      values ('577de63321333398d11a1124', 94, 'airBrakeKey', 'AirBrake', 'generic', true, 'generic', 5012, '54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2018-09-11', '2018-09-11');
+      values ('577de63321333398d11a1124', 94, 'airBrakeKey', 'Airbrake', 'generic', true, 'account', 5012, '54188262bc4d591ba438d62a', '54188262bc4d591ba438d62a', '2018-09-11', '2018-09-11');
     end if;
 
     -- newRelicKey master integration


### PR DESCRIPTION
https://github.com/Shippable/admiral/issues/2874

Following queries are already run on RC Database.

```
delete from "masterIntegrationFields" where "masterIntegrationId" = '577de63321333398d11a1124';
delete from "masterIntegrations" where id = '577de63321333398d11a1124';
```