### PR TITLE
[misc] bump the copyright year in the footer to 2019

### DIFF
--- a/static/scripts/dashboard/dashboardNew.html
+++ b/static/scripts/dashboard/dashboardNew.html
@@ -4541,7 +4541,7 @@
 
   <!-- FOOTER -->
   <footer class="footer text-right">
-  2018 © Shippable.
+  2019 © Shippable.
   </footer>
   <!-- End FOOTER -->
 


### PR DESCRIPTION
As per the title, this is a trivial change.